### PR TITLE
Add JSON fixtures and application profile documentation

### DIFF
--- a/application_profile.md
+++ b/application_profile.md
@@ -1,0 +1,112 @@
+# DLME Application Profile and Schema Mapping
+
+## Assumptions for initial prototype
+
+* DLME needs to aggregate data about cultural heritage objects sourced from
+multiple institutions using various schemas into a common index
+* Any application profile, model, used etc. for DLME should be based on a
+preexisting application profile, and document any needed divergences
+* For the prototype phase, any downstream publication or production of RDF
+should be considered secondary
+* Subsequently, context classes may not be applicable if data is only available
+as literals
+
+## Application profile
+
+
+The DLME Prototype Application Profile a subset of the [Europeana Data Model](http://pro.europeana.eu/share-your-data/data-guidelines/edm-documentation).
+Currently, the Application Profile only focuses on implementation of EDM's core
+classes (i.e. `ore:Aggregation`, `edm:ProvidedCHO`, and `edm:WebResource`), plus
+the [EDM Profile for IIIF](http://pro.europeana.eu/files/Europeana_Professional/Share_your_data/Technical_requirements/EDM_profiles/IIIFtoEDM_profile_042016.pdf).
+
+![Drawing of basic model](model.png)
+
+### Expectation key
+
+| Code   | Description |
+| ------ | ----------- |
+| **M**  | Mandatory   |
+| **M+** | Mandatory if applicable |
+| **R**  | Recommended |
+| **R+** | Recommended if applicable |
+
+### Namespaces
+
+```turtle
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix edm: <http://www.europeana.eu/schemas/edm/> .
+@prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix owl: <https://www.w3.org/2002/07/owl#> .
+@prefix svcs: <http://rdfs.org/sioc/services#> .
+```
+
+### `edm:ProvidedCHO`
+
+| Solr field name  | Property          | Req? | Cardinality | Value type  | Notes                      |
+| ---------------- | ----------------- | ---- | ----------- | ----------- | -------------------------- |
+| cho_alternative  | `dct:alternative` |      | 0...n       | literal     |                            |
+| cho_contributor  | `dc:contributor`  | R    | 0...n       | literal     |                            |
+| cho_coverage     | `dc:coverage`     | R    | 0...n       | literal     |                            |
+| cho_creator      | `dc:creator`      | R    | 0...n       | literal     |                            |
+| cho_date         | `dc:date`         | R    | 0...n       | literal     |                            |
+| cho_dc_rights    | `dc:rights`       |      | 0...n       | literal/ref | Use to give the name of the rights holder of the CHO if possible or for more general rights information; prefer `edm:rights` if more applicable |
+| cho_description  | `dc:description`  | R    | 0...n       | literal     |                            |
+| cho_edm_type     | `edm:type`        | R    | 0...n       | literal     | constrained list for facets |
+| cho_extent       | `dct:extent`      |      | 0...n       | literal     |                            |
+| cho_format       | `dc:format`       |      | 0...n       | literal     |                            |
+| cho_has_part     | `dct:hasPart`     |      | 0...n       | literal/ref |                            |
+| cho_has_type     | `edm:hasType`     | R    | 0...n       | literal     |                            |
+| cho_identifier   | `dc:identifier`   |      | 0...n       | literal/ref |                            |
+| cho_is_part_of   | `dct:isPartOf`    |      | 0...n       | literal/ref |                            |
+| cho_language     | `dc:language`     | M+   | 0...n       | literal     | Mandatory for text in Europeana; determine if BCP47 language tags are feasible |
+| cho_medium       | `dct:medium`      |      | 0...n       | literal     |                            |
+| cho_provenance   | `dct:provenance`  | R+   | 0...n       | literal     | Recommended if available   |
+| cho_publisher    | `dc:publisher`    |      | 0...n       | literal     |                            |
+| cho_relation     | `dc:relation`     |      | 0...n       | literal/ref |                            |
+| cho_same_as      | `owl:sameAs`      | R+   | 0...n       | reference   |                            |
+| cho_source       | `dc:source`       |      | 0...n       | literal/ref |                            |
+| cho_spatial      | `dct:spatial`     | R    | 0...n       | literal     |                            |
+| cho_subject      | `dc:subject`      | R    | 0...n       | literal     |                            |
+| cho_temporal     | `dct:temporal`    | R    | 0...n       | literal     |                            |
+| cho_title        | `dc:title`        | M    | 1...n       | literal     |                            |
+| cho_type         | `dc:type`         | R    | 0...n       | literal     | cf `edm:type` for faceting |
+
+### `ore:Aggregation`
+
+| Solr field name    | Property            | Req? | Cardinality | Value type  | Notes                      |
+| ------------------ | ------------------- | ---- | ----------- | ----------- | -------------------------- |
+| id                 | n/a                 | M    | 1...1       | literal     | Used to generate URIs in application. Should be generated by combination of source data ID and a provider ID |
+| agg_aggregated_cho | `edm:aggregatedCHO` | M    | 1...1       | reference   | Solr document represents aggregation; inferred 1:1 relationship with the ProvidedCHO instance. derive from data if possible |
+| agg_data_provider  | `edm:dataProvider`  | M    | 1...1       | literal     |                            |
+| agg_dc_rights      | `dc:rights`         |      | 0...n       | literal     | Ideally this should be applied to the `edm:WebResource` or the `edm:ProvidedCHO`. |
+| agg_edm_rights     | `edm:rights`        | R    | 1...n       | reference   | The rights statement that applies to an associated `edm:WebResource` when it doesn't have its own |
+| agg_has_view       | `edm:hasView`       |      | 0...n       | JSON literal | The URL of a web resource which is a digital representation of the CHO. |
+| agg_is_shown_at    | `edm:isShownAt`     | M+   | 0...1       | JSON literal | The URL of a web view of the object in full information context. |
+| agg_is_shown_by    | `edm:isShownBy`     | M+   | 0...1       | JSON literal | The URL of a web view of the object. (Europeana presumes this is renderable in the browser) |
+| agg_preview        | `edm:preview`       | M+   | 0...1       | JSON literal | The URL of a web view of the object used as a thumbnail. This must be an image regardless of the type of object. |
+| agg_provider       | `edm:provider`      | M    | 1...1       | literal     |                            |
+| agg_same_as        | `owl:sameAs`        | R+   | 0...n       | reference   |                            |
+
+### `edm:WebResource`
+
+| JSON property name  | Property             | Req? | Cardinality | Value type   | Notes                      |
+| ------------------- | -------------------- | ---- | ----------- | ------------ | -------------------------- |
+| wr_id               | See notes            | M    | 1...1       | reference    | represents the URI for the `edm:WebResource` associated with a `ore:Aggregation` using `edm:hasView`, `edm:isShownAt`, `edm:isShownBy`, or `edm:preview` |
+| wr_creator          | `dc:creator`         |      | 0...n       | literal      |                            |
+| wr_dc_rights        | `dc:rights`          |      | 0...n       | literal      | prefer `edm:rights` if available |
+| wr_description      | `dc:description`     |      | 0...n       | literal      |                            |
+| wr_edm_rights       | `edm:rights`         | R    | 0...1       | reference    |                            |
+| wr_format           | `dc:format`          | R    | 0...n       | literal      |                            |
+| wr_has_service      | `svcs:has_service`   | R*   | 0...n       | JSON literal | for associating IIIF image resources see [EDM Profile for IIIF](http://pro.europeana.eu/files/Europeana_Professional/Share_your_data/Technical_requirements/EDM_profiles/IIIFtoEDM_profile_042016.pdf) |
+| wr_is_referenced_by | `dct:isReferencedBy` | R*   | 0...n       | reference    | for associating IIIF presentation API resources; see [EDM Profile for IIIF](http://pro.europeana.eu/files/Europeana_Professional/Share_your_data/Technical_requirements/EDM_profiles/IIIFtoEDM_profile_042016.pdf) |
+
+### `svcs:Service`
+
+| JSON property name  | Property             | Req? | Cardinality | Value type   | Notes                      |
+| ------------------- | -------------------- | ---- | ----------- | ------------ | -------------------------- |
+| service_id          | See notes            | M    | 1...1       | reference    | represents the URI for the `svcs:Service` associated with a `edm:WebResource` using `svcs:has_service` |
+| service_conforms_to | `dct:conformsTo`     | M    | 1...n       | reference    | for associating IIIF image services; see [EDM Profile for IIIF](http://pro.europeana.eu/files/Europeana_Professional/Share_your_data/Technical_requirements/EDM_profiles/IIIFtoEDM_profile_042016.pdf) |
+| service_implements  | `doap:implements`    | R    | 0...1       | reference    | for associating IIIF image profiles; see [EDM Profile for IIIF](http://pro.europeana.eu/files/Europeana_Professional/Share_your_data/Technical_requirements/EDM_profiles/IIIFtoEDM_profile_042016.pdf) |
+

--- a/spec/fixtures/json/embeddable.json
+++ b/spec/fixtures/json/embeddable.json
@@ -1,0 +1,25 @@
+{
+  "id": "sketchfab_0a29475b11334f75a394fc95ff70dffa",
+  "agg_data_provider": "David Anderson",
+  "agg_edm_rights": "http://rightsstatements.org/vocab/InC/1.0/",
+  "agg_is_shown_at": {
+    "wr_id": "https://sketchfab.com/models/0a29475b11334f75a394fc95ff70dffa"
+  },
+  "agg_is_shown_by": {
+    "wr_id": "https://dg5bepmjyhz9h.cloudfront.net/urls/0a29475b11334f75a394fc95ff70dffa/dist/thumbnails/553cb09cb34d4bdd813d8bfcb9c79d48/1024.jpeg",
+    "wr_format": "image/jpeg"
+  },
+  "agg_preview": {
+    "wr_id": "https://dg5bepmjyhz9h.cloudfront.net/urls/0a29475b11334f75a394fc95ff70dffa/dist/thumbnails/553cb09cb34d4bdd813d8bfcb9c79d48/448.jpeg"
+  },
+  "agg_provider": "Sketchfab",
+  "cho_contributor": "David Anderson",
+  "cho_coverage": ["Egypt"],
+  "cho_creator": "David Anderson",
+  "cho_date": "2015",
+  "cho_description": "Statue of the goddess Sekhmet from the reign of Amenhotep III, Dynasty 18.  In the San Antonio Art Museum. Created from 27 mobile phone pictures.  Lighting conditions were poor and caused highlight burn outs on front of statue.  Also was unable to obtain photos of top of head so this has been infilled using 3d software",
+  "cho_edm_type": "3D Model",
+  "cho_spatial": ["Egypt"],
+  "cho_title": "Sekhmet Statue",
+  "cho_type": ["statue", "photogrammetry"],
+}

--- a/spec/fixtures/json/iiif-single-image.json
+++ b/spec/fixtures/json/iiif-single-image.json
@@ -1,0 +1,32 @@
+{
+  "id": "princeton_x920fz18z",
+  "agg_data_provider": "Princeton University. Firestone Library",
+  "agg_edm_rights": "http://www.princeton.edu/~rbsc/research/rights.html",
+  "agg_is_shown_at": {
+    "wr_id": "http://arks.princeton.edu/ark:/88435/x920fz18z"
+  },
+  "agg_is_shown_by": {
+    "wr_id": "http://libimages.princeton.edu/loris2/pudl0100/posters/eg1_0026/00000001.jp2/full/200,/0/default.jpg",
+    "wr_format": "image/jpeg",
+    "wr_has_service": [{
+      "service_id": "https://libimages.princeton.edu/loris/pudl0100%2Fposters%2Feg1_0026%2F00000001.jp2",
+      "service_conforms_to": "http://iiif.io/api/image",
+      "service_implements": "http://iiif.io/api/image/2/level2.json"
+    }]
+  },
+  "agg_preview": {
+    "wr_id": "http://libimages.princeton.edu/loris2/pudl0100/posters/eg1_0026/00000001.jp2/full/200,/0/default.jpg"
+  },
+  "agg_provider": "Princeton University",
+  "cho_contributor": ["نور الشريف", "نورا", "محمد عبد العزي"],
+  "cho_coverage": ["Egypt"],
+  "cho_date": "1985",
+  "cho_description": "Statue of the goddess Sekhmet from the reign of Amenhotep III, Dynasty 18.  In the San Antonio Art Museum. Created from 27 mobile phone pictures.  Lighting conditions were poor and caused highlight burn outs on front of statue.  Also was unable to obtain photos of top of head so this has been infilled using 3d software",
+  "cho_edm_type": "Image",
+  "cho_identifier": "eg1-0026",
+  "cho_is_part_of": "http://pudl.princeton.edu/collections/pudl0100",
+  "cho_language": "Arabic",
+  "cho_spatial": ["Egypt"],
+  "cho_title": "أجراس الخطر",
+  "cho_type": "Posters",
+}

--- a/spec/fixtures/json/iiif-with-manifest.json
+++ b/spec/fixtures/json/iiif-with-manifest.json
@@ -1,0 +1,45 @@
+{
+  "id": "stanford_tk780vf9050",
+  "agg_data_provider": "Walters Art Museum",
+  "agg_edm_rights": "http://creativecommons.org/licenses/by-sa/3.0/",
+  "agg_is_shown_at": {
+    "wr_id": "https://purl.stanford.edu/tk780vf9050"
+  },
+  "agg_is_shown_by": {
+    "wr_id": "https://stacks.stanford.edu/image/iiif/tk780vf9050%2FW586_000001_300/full/!400,400/0/default.jpg",
+    "wr_format": "image/jpeg",
+    "wr_has_service": [{
+      "service_id": "https://stacks.stanford.edu/image/iiif/tk780vf9050%252FW586_000001_300",
+      "service_conforms_to": "http://iiif.io/api/image",
+      "service_implements": "http://iiif.io/api/image/2/level1.json"
+    }],
+    "wr_is_referenced_by": "https://purl.stanford.edu/tk780vf9050/iiif/manifest"
+  },
+  "agg_preview": {
+    "wr_id": "https://stacks.stanford.edu/image/iiif/tk780vf9050%2FW586_000001_300/full/256,/0/default.jpg"
+  },
+  "agg_provider": "Stanford University",
+  "cho_alternative": ["al-Shifāʾ fī taʿrīf ḥuqūq al-Muṣṭafá", "الشفاء في تعريف حقوق المصطفى"],
+  "cho_contributor": "Salīm al-Rashīd",
+  "cho_coverage": ["England", "Kinsham"],
+  "cho_creator": [
+    "Abū al-Faḍl ʿIyāḍ ibn Mūsá al-Yaḥṣubī al-Bāhilī",
+    "ʿIyāḍ al-Yaḥṣubī (d. 544 AH / 1149 CE)", 
+    "ابو الفضل عياض بن موسى اليحصبي الباهلي"
+  ],
+  "cho_date": "1777",
+  "cho_dc_rights": "Licensed for use under Creative Commons Attribution-ShareAlike 3.0 Unported Access Rights, http://creativecommons.org/licenses/by-sa/3.0/legalcode. Images are free for any use, provided you follow the terms of this license. You do not need to apply to the Walters prior to using the images. We ask only that you cite the source of the images as the Walters Art Museum (see citation style at http://www.thedigitalwalters.org/03_ReadMe.html). Additionally, we request that a copy of any work created using these materials be sent to the Curator of Manuscripts and Rare Books at the Walters Art Museum, 600 N. Charles Street, Baltimore, MD 21201, mss-curator@thewalters.org.",
+  "cho_description": "This manuscript is an illuminated copy of the popular work on the duties of Muslims toward the Prophet Muhammad known as al-Shifāʾ by ʿIyāḍ al-Yaḥṣubī (d. 544 AH / 1149 CE). According to the colophon, it was completed in 1191 AH / 1777 CE by Salīm al-Rashīd. The text is written in Turkish naskh script in black ink with incidentals in red and gold. The dark brown leather binding is contemporary with the manuscript. For full description, see http://www.thedigitalwalters.org/Data/WaltersManuscripts/html/W586/description.html",
+  "cho_edm_type": "Manuscript",
+  "cho_extent": "18.0 x 10.5cm",
+  "cho_is_part_of": "http://purl.stanford.edu/ww121ss5000",
+  "cho_language": "Arabic",
+  "cho_provenance": [
+    "Seal impression with the name al-Sayyid Abū Bakr al-Ḥilmī and the date 1281[?]AH / 1864-5[?] CE (fol. 1a)",
+    "Walters Art Museum, 1931, by Henry Walters bequest"
+  ],
+  "cho_same_as": "http://www.thedigitalwalters.org/Data/WaltersManuscripts/html/W586/",
+  "cho_spatial": ["Turkey"],
+  "cho_title": "Walters Ms. W.586, Work on the duties of Muslims toward the Prophet Muhammad with an account of his life",
+  "cho_type": "Manuscript"
+}

--- a/spec/fixtures/json/link-only.json
+++ b/spec/fixtures/json/link-only.json
@@ -1,0 +1,43 @@
+{
+  "id": "penn_ljs394",
+  "agg_data_provider": "University of Pennsylvania. Rare Book & Manuscript Library",
+  "agg_edm_rights": "http://creativecommons.org/publicdomain/mark/1.0/",
+  "agg_is_shown_at": {
+    "wr_id": "http://openn.library.upenn.edu/Data/0001/html/ljs394.html"
+  },
+  "agg_is_shown_by": {
+    "wr_id": "http://openn.library.upenn.edu/Data/0001/ljs394/data/web/0085_0000_web.jpg",
+    "wr_format": "image/jpeg"
+  },
+  "agg_preview": {
+    "wr_id": "http://openn.library.upenn.edu/Data/0001/ljs394/data/thumb/0085_0000_thumb.jpg"
+  },
+  "agg_provider": "University of Pennsylvania",
+  "agg_same_as": "http://hdl.library.upenn.edu/1017/d/medren/5440810",
+  "cho_coverage": ["Egypt", "Syria"],
+  "cho_creator": "Jawharī, Ismāʻīl ibn Ḥammād, d. 1003?",
+  "cho_date": "13--",
+  "cho_description": "Volume from a 14th-century copy of a 10th-century dictionary of the Arabic language. Words are indexed by their last root letter, with this volume covering the letters za' to lam. Marginal notes by a reader and proofreader. Later pastedown on inner cover has remedies written in Arabic and Persian.",
+  "cho_edm_type": "Text",
+  "cho_extent": "203 leaves : 269 x 172 (198 x 125) mm. bound to 269 x 180 mm",
+  "cho_has_type": [
+    "Codices",
+    "Dictionaries",
+    "Illuminations (visual works)"
+    "Manuscripts, Arabic--14th century"
+    "Manuscripts, Medieval"
+  ],
+  "cho_identifier": "5440810",
+  "cho_is_part_of": "http://openn.library.upenn.edu/html/0001.html",
+  "cho_language": ["Arabic", "Persian"],
+  "cho_provenance": [
+    "Ownership stamps on title page canceled (f. 1r).",
+    "Sold by Sam Fogg Ltd. (London) to Lawrence J. Schoenberg, Nov. 2000.",
+    "Deposit by Lawrence J. Schoenberg and Barbara Brizdle, 2011."
+  ],
+  "cho_spatial": ["Egypt", "Syria"],
+  "cho_subject": ["Arabic language", "Traditional medicine--Formulae, receipts, prescriptions"],
+  "cho_temporal": "14th century",
+  "cho_title": "Section of Tāj al-lughah wa-ṣiḥāḥ al-ʻArabīyah",
+  "cho_type": "Dictionaries",
+}


### PR DESCRIPTION
Adds four fixtures: 1) embeddable object (Sketchfab); 2) single IIIF image;
3) an IIIF resource w/ a manifest, and 4) one with a link only.

Also adds the draft application profile documentation.