### PR TITLE
Copy index styling from exhibits to align thumbnails a little better

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -3,3 +3,38 @@
 @import 'bootstrap';
 
 @import 'blacklight/blacklight';
+
+#documents {
+  .index_title {
+    font-size: $font-size-large;
+    margin-top: 0;
+  }
+
+  &.documents-list {
+    .document {
+      box-sizing: content-box;
+      min-height: 100px;
+      padding-bottom: $padding-large-vertical;
+      padding-top: $padding-large-vertical;
+    }
+
+    .documentHeader,
+    .document-metadata {
+      margin-left: 120px;
+    }
+
+    .document-thumbnail {
+      float: left;
+      height: 0;
+      margin: 0;
+      padding: 0;
+
+      // we don't know what size thumbnails we're getting so enforce
+      // hard constraints for the index view
+      img {
+        max-height: 200px;
+        width: 100px;
+      }
+    }
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,6 +9,7 @@ class CatalogController < ApplicationController
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
 
+    config.view.list.partials = %i[thumbnail index_header index]
     config.view.gallery.partials = %i[index_header index]
     config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]


### PR DESCRIPTION
<img width="521" alt="screen shot 2017-08-08 at 7 55 10 am" src="https://user-images.githubusercontent.com/111218/29078345-ee012c48-7c0e-11e7-9b9d-64808000ac1c.png">
