### PR TITLE
Set RAILS_MAX_THREADS

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -595,6 +595,9 @@ Resources:
         OptionName: RDS_PORT
         Value: !GetAtt [DBInstance, Endpoint.Port]
       - Namespace: aws:elasticbeanstalk:application:environment
+        OptionName: RAILS_MAX_THREADS
+        Value: 5
+      - Namespace: aws:elasticbeanstalk:application:environment
         OptionName: AWS_REGION
         Value: !Ref 'AWS::Region'
       - Namespace: aws:elasticbeanstalk:application:environment


### PR DESCRIPTION
This will also control the sidekiq concurrency:

https://github.com/mperham/sidekiq/commit/52828e42123cc1c54b2a326bda5d00965ec05acb#diff-411201f0104d91346964914342a07cefR212

We hope this will fix sidekiq errors like:

> ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use
 


