### PR TITLE
Force SSL except for health checks (e.g. from the load balancer)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /^\/status/ }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Fixes #119, among others, where javascript doesn't load via http.