### PR TITLE
Fix for Honeybadger error on missing tr method.

### DIFF
--- a/lib/traject/macros/csv.rb
+++ b/lib/traject/macros/csv.rb
@@ -23,7 +23,7 @@ module Macros
 
     def normalize_numismatic_date
       lambda do |row, accumulator, _context|
-        accumulator << row['Year'].tr('|', '-')
+        accumulator << row['Year'].to_s.tr('|', '-')
       end
     end
   end


### PR DESCRIPTION
Quick fix for the Honeybadger error (#34481413) on missing tr method for numbers.