### PR TITLE
Update Manage Data page and superadmin sidebar

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -7,3 +7,5 @@ $color-gray-lightest: #f5f5f5;
 
 $clir-burgundy: #560319;
 $dlf-blue:      #046BA5;
+
+$text-muted: $color-black-medium; // with gray body bg, need darker muted color

--- a/app/views/harvests/index.html.erb
+++ b/app/views/harvests/index.html.erb
@@ -6,7 +6,7 @@
 
   <% pipelines = Pipeline.all.pluck(:id, :name).to_h %>
   <table class="table">
-    <caption>Number of files imported in each pipeline</caption>
+    <caption>Files imported in each pipeline.</caption>
     <thead>
       <tr>
         <th>When</th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
     curation:
       sidebar:
         sources: 'Sources'
+        harvests: 'Manage data'
     resources:
       upload:
         form:


### PR DESCRIPTION
Very minor updates:

- Change label for sidebar menu item to "Manage data" from "Harvests" so label is consistent with other sidebar actions (label starts with a verb and matches primary title of page is goes to).

- Change label for table caption on the Harvests page (because the table includes more info than just number of files) and darken text (because it'll need more contrast with the visual design updates in #254).

![manage_data_-_harvests___digital_library_of_the_middle_east](https://user-images.githubusercontent.com/101482/29900406-849f2b2a-8da6-11e7-9c24-48c58f81f5be.png)
