### PR TITLE
Record additional context within the DlmeJson and index it appropriately

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -86,6 +86,8 @@ class CatalogController < ApplicationController
        week: { label: 'within 7 days', fq: "timestamp:[#{(Time.zone.now - 7.days).iso8601} TO *]" },
        month: { label: 'within 31 days', fq: "timestamp:[#{(Time.zone.now - 31.days).iso8601} TO *]" }
     }
+    config.add_facet_field 'traject config', field: 'traject_context_source_ssim', limit: true
+    config.add_facet_field 'harvest', field: 'traject_context_harvest_id_ssim', limit: true
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,20 +71,20 @@ class CatalogController < ApplicationController
     config.add_facet_field 'data provider', field: 'agg_provider_ssim', limit: true
     config.add_facet_field 'thumbnail', query: {
       yes: { label: 'Yes', fq: 'agg_preview.wr_id_ssim:[* TO *]' },
-      no: { label: 'No', fq: '-agg_preview.wr_id_ssim:[* TO *]' },
+      no: { label: 'No', fq: '-agg_preview.wr_id_ssim:[* TO *]' }
     }
     config.add_facet_field 'shown at', query: {
       yes: { label: 'Yes', fq: 'agg_is_shown_at.wr_id_ssim:[* TO *]' },
-      no: { label: 'No', fq: '-agg_is_shown_at.wr_id_ssim:[* TO *]' },
+      no: { label: 'No', fq: '-agg_is_shown_at.wr_id_ssim:[* TO *]' }
     }
     config.add_facet_field 'empty fields', query: {
       no_cho_title:     { label: 'No CHO Title', fq: '-cho_title_ssim:[* TO *]' },
-      no_cho_dc_rights: { label: 'No CHO DC Rights', fq: "-cho_dc_rights_ssim:[* TO *]" },
+      no_cho_dc_rights: { label: 'No CHO DC Rights', fq: '-cho_dc_rights_ssim:[* TO *]' }
     }
     config.add_facet_field 'indexed at', query: {
-       day: { label: 'within 1 day', fq: "timestamp:[#{(Time.zone.now - 1.day).iso8601} TO *]" },
-       week: { label: 'within 7 days', fq: "timestamp:[#{(Time.zone.now - 7.days).iso8601} TO *]" },
-       month: { label: 'within 31 days', fq: "timestamp:[#{(Time.zone.now - 31.days).iso8601} TO *]" }
+      day: { label: 'within 1 day', fq: "timestamp:[#{(Time.zone.now - 1.day).iso8601} TO *]" },
+      week: { label: 'within 7 days', fq: "timestamp:[#{(Time.zone.now - 7.days).iso8601} TO *]" },
+      month: { label: 'within 31 days', fq: "timestamp:[#{(Time.zone.now - 31.days).iso8601} TO *]" }
     }
     config.add_facet_field 'traject config', field: 'traject_context_source_ssim', limit: true
     config.add_facet_field 'harvest', field: 'traject_context_harvest_id_ssim', limit: true

--- a/app/jobs/create_resource_job.rb
+++ b/app/jobs/create_resource_job.rb
@@ -4,9 +4,9 @@
 class CreateResourceJob < ApplicationJob
   queue_as :default
 
-  def perform(id, exhibit, json)
+  def perform(id, exhibit, json, metadata = {})
     resource = DlmeJson.find_or_initialize_by(url: id, exhibit_id: exhibit.id)
-    resource.data = { json: json }
+    resource.attributes = { json: json, metadata: metadata }
     unless resource.save
       logger.warn "Unable to save resource #{id} because: #{resource.errors.full_messages}"
       return

--- a/app/models/dlme_json.rb
+++ b/app/models/dlme_json.rb
@@ -6,10 +6,16 @@ class DlmeJson < Spotlight::Resource
   validate :valid_json_syntax?
   validate :valid_schema?
 
+  store :data, accessors: %i[json metadata]
+
   # @return [Hash]
   # @raise [JSON::ParserError] if the json is not parsable
   def json
-    @json ||= JSON.parse(data[:json])
+    @json ||= JSON.parse(super)
+  end
+
+  def metadata
+    super || {}
   end
 
   private

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -20,6 +20,8 @@ class Pipeline < ApplicationRecord
   private
 
   def traject_config(resource)
-    config.properties.to_h.merge('command_line.filename' => resource.original_filename)
+    config.properties.to_h.merge('command_line.filename' => resource.original_filename,
+                                 'harvested_resource_id' => resource.id,
+                                 'harvest_id' => resource.harvest_id)
   end
 end

--- a/app/resource_builders/dlme_json_resource_builder.rb
+++ b/app/resource_builders/dlme_json_resource_builder.rb
@@ -18,6 +18,7 @@ class DlmeJsonResourceBuilder < Spotlight::SolrDocumentBuilder
     source = resource.json
     { 'id' => source['id'], '__raw_resource_json_ss' => JSON.pretty_generate(source) }.tap do |sink|
       transform_to_untokenized_solr_fields(source, sink: sink)
+      transform_to_untokenized_solr_fields(resource.metadata, sink: sink)
 
       TOKENIZED_COPY_FIELDS.each do |key|
         sink["#{key}_tsim"] = source[key] if source[key]

--- a/lib/traject/dlme_json_resource_writer.rb
+++ b/lib/traject/dlme_json_resource_writer.rb
@@ -26,13 +26,21 @@ class DlmeJsonResourceWriter
     attributes = context.output_hash.dup
     id = attributes.fetch('id').first
     json = JSON.generate(AdjustCardinality.call(attributes)).unicode_normalize
-    create_resource(id, json)
+    create_resource(id, json, metadata(context))
   end
 
   private
 
-  def create_resource(id, json)
-    CreateResourceJob.perform_later(id, @exhibit, json)
+  def create_resource(id, json, metadata)
+    CreateResourceJob.perform_later(id, @exhibit, json, metadata)
+  end
+
+  def metadata(context)
+    keys = ['command_line.filename', 'source', 'position', 'harvested_resource_id', 'harvest_id']
+
+    context.settings.slice(*keys).transform_keys do |key|
+      "traject_context_#{key}"
+    end
   end
 
   delegate :logger, to: :Rails

--- a/spec/models/pipeline_spec.rb
+++ b/spec/models/pipeline_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Pipeline, type: :model do
   describe '#indexer' do
     subject(:indexer) { described_class.for('stanford_mods').indexer(resource) }
 
-    let(:resource) { HarvestedResource.new(original_filename: 'x.csv') }
+    let(:resource) { create(:harvested_resource, original_filename: 'x.csv') }
 
     it 'creates a new traject indexer for a resource' do
       expect(indexer).to be_a_kind_of Traject::Indexer
@@ -14,6 +14,11 @@ RSpec.describe Pipeline, type: :model do
 
     it 'sets the original filename from the provided resource' do
       expect(indexer.settings['command_line.filename']).to eq 'x.csv'
+    end
+
+    it 'sets the harvest context' do
+      expect(indexer.settings['harvested_resource_id']).to eq resource.id
+      expect(indexer.settings['harvest_id']).to eq resource.harvest.id
     end
   end
 end

--- a/spec/resource_builders/dlme_json_resource_builder_spec.rb
+++ b/spec/resource_builders/dlme_json_resource_builder_spec.rb
@@ -4,9 +4,13 @@ require 'rails_helper'
 
 RSpec.describe DlmeJsonResourceBuilder do
   let(:doc_builder) { described_class.new(resource) }
-  let(:resource) { DlmeJson.new(data: { json: json }) }
+  let(:resource) { DlmeJson.new(json: json, metadata: metadata) }
   let(:fixture_file_path) { File.join(fixture_path, 'json/iiif-single-image.json') }
   let(:json) { File.open(fixture_file_path).read }
+  let(:metadata) do
+    { 'traject_context_command_line.filename' => fixture_file_path,
+      'traject_context_source' => 'dlme_json_resource_spec' }
+  end
 
   describe 'to_solr' do
     subject(:solr_doc) { doc_builder.to_solr }
@@ -66,6 +70,11 @@ RSpec.describe DlmeJsonResourceBuilder do
 
     it 'adds sortable fields for title' do
       expect(solr_doc).to include 'sortable_cho_title_ssi' => 'افواه و ارانب'
+    end
+
+    it 'includes metadata context fields' do
+      expect(solr_doc).to include 'traject_context_command_line.filename_ssim' => fixture_file_path,
+                                  'traject_context_source_ssim' => 'dlme_json_resource_spec'
     end
   end
 end


### PR DESCRIPTION
For now, this context may include these settings:
 - command_line.filename (the original provided name when running traject)
 - source (used as a key for our import configuration)
 - position (record N of M in a batch)
 - harvest_id
 - harvest_resource_id