### PR TITLE
Limit Princeton Movie Poster indexing to MODS

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,6 +58,7 @@ import:
         inst_id: met
     princeton_mods:
       directory: movie-posters/records/princeton
+      only: !ruby/regexp '/(.*)+.mods/'
       traject_file: mods_config
       properties:
         agg_provider: Princeton University Library

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,7 +58,7 @@ import:
         inst_id: met
     princeton_mods:
       directory: movie-posters/records/princeton
-      only: !ruby/regexp '/(.*)+.mods/'
+      only: !ruby/regexp '/\.mods$/'
       traject_file: mods_config
       properties:
         agg_provider: Princeton University Library


### PR DESCRIPTION
We received METS data that includes paths for the thumbs and full-size images. This limits the indexing to just the MODS records for now.