### PR TITLE
Standardize Penn Libaries Names

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,7 +40,7 @@ import:
       directory: manuscript/records/penn/schoenberg
       traject_file: tei_config
       properties:
-        agg_provider: University of Pennsylvania Library
+        agg_provider: University of Pennsylvania Libraries
         inst_id: penn
     stanford_mods:
       directory: maps/records/stanford

--- a/spec/import/tei_transform_spec.rb
+++ b/spec/import/tei_transform_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Transforming TEI files' do
       expect(dlme['cho_subject']).to include 'Manuscripts, Medieval'
       expect(dlme['cho_subject']).to include 'Arabic language--Dictionaries'
       expect(dlme['cho_subject']).to include 'Traditional medicine--Formulae, receipts, prescriptions'
-      expect(dlme['agg_provider']).to eq 'University of Pennsylvania Library'
+      expect(dlme['agg_provider']).to eq 'University of Pennsylvania Libraries'
       expect(dlme['agg_data_provider']).to eq 'Rare Book & Manuscript Library, University of Pennsylvania'
       expect(dlme['agg_edm_rights']).to eq ['http://creativecommons.org/publicdomain/mark/1.0/']
     end


### PR DESCRIPTION
Updates the  for Penn Libraries to be 'University of Pennsylvania Libraries' for all datasets.

closes #281