### PR TITLE
Dockerize the web app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# This image's actual base image
+FROM starefossen/ruby-node:2-10
+
+LABEL maintainer="Aaron Collier <aaron.collier@stanford.edu>"
+
+# Set default RAILS environment
+ENV RAILS_ENV=production
+ENV RAILS_SERVE_STATIC_FILES=true
+
+# Create and set the working directory as /opt
+WORKDIR /opt
+
+# Expose port 3000
+EXPOSE 3000
+
+# Copy the Gemfile and Gemfile.lock, and run bundle install prior to copying all source files
+# This is an optimization that will prevent the need to re-run bundle install when only source
+# code is changed and not dependencies.
+COPY Gemfile /opt
+COPY Gemfile.lock /opt
+
+RUN bundle install
+
+COPY . .
+# Start the server by default, listening for all connections
+CMD puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Requires docker.
 
 ```console
 $ docker-compose up -d
+[FIRST RUN]
+$ docker-compose run app rake db:setup
+$ docker-compose stop
+$ docker-compose up -d
+[ -------- ]
 $ docker ps (to retrieve the container id)
 $ docker exec -it (container id) /bin/sh
 $ rake spotlight:initialize #new shell window

--- a/README.md
+++ b/README.md
@@ -31,14 +31,13 @@ And these database configuration settings:
 
 ## Local Development
 
-Most recently run with Ruby 2.5.3
-
-After running bundle install you can spin up the rails server, jetty, and populate the solr index using these commands:
+Requires docker.
 
 ```console
-$ bundle exec solr_wrapper 
+$ docker-compose up -d
+$ docker ps (to retrieve the container id)
+$ docker exec -it (container id) /bin/sh
 $ rake spotlight:initialize #new shell window
-$ REMOTE_USER=admin@admin.edu bundle exec rails s
 ```
 
 Once the dlme rails app is running you can create an exhibit. The title will need to be 'dlme' and the URL slug will need to be 'library'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,8 +45,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
-  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /^\/status/ } } }
+  # config.force_ssl = true
+  # config.ssl_options = { redirect: { exclude: -> request { request.path =~ /^\/status/ } } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - RDS_PASSWORD=sekret
       - RDS_HOSTNAME=db
       - RDS_PORT=5432
+      - SOLR_URL=http://localhost:8983/solr/dlme
       - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
     image: 'suldlss/dlme:latest'
     ports:
@@ -27,6 +28,18 @@ services:
       - POSTGRES_PASSWORD=sekret
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
+    networks:
+      - dlme
+  solr:
+    image: solr
+    ports:
+      - "8983:8983"
+    volumes:
+      - ./solr-data:/opt/solr/server/solr/mycores"
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - dlme
     networks:
       - dlme
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: ./
+    environment:
+      - RAILS_LOG_TO_STDOUT=true
+    image: 'suldlss/dlme:latest'
+    ports:
+      - "3000"
+  ruby:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile.ruby
+    image: 'suldlss/dlme:ruby-latest'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,28 @@ services:
       context: ./
     environment:
       - RAILS_LOG_TO_STDOUT=true
+      - RDS_DB_NAME=dlme
+      - RDS_USERNAME=postgres
+      - RDS_PASSWORD=sekret
+      - RDS_HOSTNAME=db
+      - RDS_PORT=5432
+      - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
     image: 'suldlss/dlme:latest'
     ports:
-      - "3000"
-  ruby:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile.ruby
-    image: 'suldlss/dlme:ruby-latest'
+      - "3000:3000"
+    depends_on:
+      - db
+    networks:
+      - dlme
+  db:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=sekret
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    networks:
+      - dlme
+networks:
+  dlme:


### PR DESCRIPTION
This:
- Adds a Dockerfile in order to register a docker image for the web app that will be usable in AWS, etc
- Adds a docker-compose.yml file that can be used in local development
- Turns off the force SSL (causes issues for local development)
- Updates README with instructions on setting up the database for local development
- Add SOLR to the docker-compose.yml

NOTE: DO NOT Merge this until confirmed we avoid the current CI/CD step.