### PR TITLE
readded namespace to bnf config files

### DIFF
--- a/lib/traject/bnf_bo_config.rb
+++ b/lib/traject/bnf_bo_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/bnf_bo_config.rb
+++ b/lib/traject/bnf_bo_config.rb
@@ -16,32 +16,30 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), split('. '), first_only, strip
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('. '), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), split('. '), first_only, strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", LOC_NS), strip, gsub(/. Fonction indéterminée/, '')
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('. '), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", LOC_NS), strip, gsub(/. Fonction indéterminée/, '')
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), first_only, strip, traLOC_NSlation_map('types')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), first_only, strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_cealex_config.rb
+++ b/lib/traject/bnf_cealex_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/bnf_cealex_config.rb
+++ b/lib/traject/bnf_cealex_config.rb
@@ -16,32 +16,30 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), split('.'), first_only, strip
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), split('.'), first_only, strip
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types'), default('image')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), split('.'), first_only, strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", LOC_NS), split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", LOC_NS), split('.'), first_only, strip
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), first_only, strip, traLOC_NSlation_map('types'), default('image')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), first_only, strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_ebaf_config.rb
+++ b/lib/traject/bnf_ebaf_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/bnf_ebaf_config.rb
+++ b/lib/traject/bnf_ebaf_config.rb
@@ -16,30 +16,28 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('.'), first_only, strip
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types'), default('image')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('.'), first_only, strip
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), first_only, strip, traLOC_NSlation_map('types'), default('image')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), first_only, strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # # Not using agg_is_shown_by

--- a/lib/traject/bnf_ideo_config.rb
+++ b/lib/traject/bnf_ideo_config.rb
@@ -14,6 +14,8 @@ settings do
   provide 'reader_class_name', 'XmlReader'
 end
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
 # Cho Required
@@ -21,15 +23,15 @@ to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), split('.'), first_only, strip
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), split('.'), first_only, strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), split('. '), first_only, strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('. '), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
 to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
 to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
 to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
 to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), strip, translation_map('types')
+to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types')
 to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
 to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
 to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip

--- a/lib/traject/bnf_ideo_config.rb
+++ b/lib/traject/bnf_ideo_config.rb
@@ -14,34 +14,32 @@ settings do
   provide 'reader_class_name', 'XmlReader'
 end
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), split('. '), first_only, strip
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('. '), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), strip, gsub(/. Fonction indéterminée/, '')
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), split('. '), first_only, strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor[2]", LOC_NS), strip, gsub(/. Fonction indéterminée/, '')
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('. '), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", LOC_NS), strip, gsub(/. Fonction indéterminée/, '')
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), first_only, strip, traLOC_NSlation_map('types')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), first_only, strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_ifao_config.rb
+++ b/lib/traject/bnf_ifao_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/bnf_ifao_config.rb
+++ b/lib/traject/bnf_ifao_config.rb
@@ -16,37 +16,35 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), strip # split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[3]", NS), split('.'), first_only, strip
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS),
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), strip # split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", LOC_NS), split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[3]", LOC_NS), split('.'), first_only, strip
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS),
          default('notated music'),
          first_only,
          strip,
-         translation_map('types'),
+         traLOC_NSlation_map('types'),
          default('image')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), first_only, strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), first_only, strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_ifea_config.rb
+++ b/lib/traject/bnf_ifea_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/bnf_ifea_config.rb
+++ b/lib/traject/bnf_ifea_config.rb
@@ -16,31 +16,29 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), split('.'), first_only, strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", NS), split('.'), first_only, strip
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), first_only, strip, translation_map('types'), default('image')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), strip, translation_map('marc_languages')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), split('.'), first_only, strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator[2]", LOC_NS), split('.'), first_only, strip
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), first_only, strip, traLOC_NSlation_map('types'), default('image')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), strip, traLOC_NSlation_map('marc_languages')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_salt_config.rb
+++ b/lib/traject/bnf_salt_config.rb
@@ -16,30 +16,28 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
-NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
-
 # Cho Required
-to_field 'id', extract_xml("#{record}/dc:identifier[1]", NS), strip
-to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip
+to_field 'id', extract_xml("#{record}/dc:identifier[1]", LOC_NS), strip
+to_field 'cho_title', extract_xml("#{record}/dc:title", LOC_NS), strip
 
 # Cho Other
-to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", NS), strip
-to_field 'cho_creator', extract_xml("#{record}/dc:creator", NS), strip
-to_field 'cho_date', extract_xml("#{record}/dc:date", NS), strip
-to_field 'cho_description', extract_xml("#{record}/dc:description", NS), strip
-to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", NS), strip
-to_field 'cho_format', extract_xml("#{record}/dc:format", NS), strip
-to_field 'cho_type', extract_xml("#{record}/dc:type", NS), prepend('text |'), split('|'), first_only, strip, default('text')
-to_field 'cho_language', extract_xml("#{record}/dc:language", NS), strip, gsub(/Ottoman Turkish/, 'Turkish, Ottoman')
-to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", NS), strip
-to_field 'cho_relation', extract_xml("#{record}/dc:relation", NS), strip
-to_field 'cho_source', extract_xml("#{record}/dc:source", NS), strip
-to_field 'cho_subject', extract_xml("#{record}/dc:subject", NS), strip
+to_field 'cho_contributor', extract_xml("#{record}/dc:contributor", LOC_NS), strip
+to_field 'cho_creator', extract_xml("#{record}/dc:creator", LOC_NS), strip
+to_field 'cho_date', extract_xml("#{record}/dc:date", LOC_NS), strip
+to_field 'cho_description', extract_xml("#{record}/dc:description", LOC_NS), strip
+to_field 'cho_dc_rights', extract_xml("#{record}/dc:rights", LOC_NS), strip
+to_field 'cho_format', extract_xml("#{record}/dc:format", LOC_NS), strip
+to_field 'cho_type', extract_xml("#{record}/dc:type", LOC_NS), prepend('text |'), split('|'), first_only, strip, default('text')
+to_field 'cho_language', extract_xml("#{record}/dc:language", LOC_NS), strip, gsub(/Ottoman Turkish/, 'Turkish, Ottoman')
+to_field 'cho_publisher', extract_xml("#{record}/dc:publisher", LOC_NS), strip
+to_field 'cho_relation', extract_xml("#{record}/dc:relation", LOC_NS), strip
+to_field 'cho_source', extract_xml("#{record}/dc:source", LOC_NS), strip
+to_field 'cho_subject', extract_xml("#{record}/dc:subject", LOC_NS), strip
 
 # Agg
 to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
-to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', NS), strip
-to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', NS), strip
+to_field 'agg_is_shown_at', extract_xml('srw:record/srw:extraRecordData/link', LOC_NS), strip
+to_field 'agg_preview', extract_xml('srw:record/srw:extraRecordData/thumbnail', LOC_NS), strip
 
 # Not using agg_is_shown_by

--- a/lib/traject/bnf_salt_config.rb
+++ b/lib/traject/bnf_salt_config.rb
@@ -16,6 +16,8 @@ end
 
 record = 'srw:record/srw:recordData/oai_dc:dc'
 
+NS = { srw: "http://www.loc.gov/zing/srw/", oai_dc: "http://www.openarchives.org/OAI/2.0/oai_dc/", dc: "http://purl.org/dc/elements/1.1/"}
+
 # Cho Required
 to_field 'id', extract_xml("#{record}/dc:identifier[1]", NS), strip
 to_field 'cho_title', extract_xml("#{record}/dc:title", NS), strip

--- a/lib/traject/macros/dlme.rb
+++ b/lib/traject/macros/dlme.rb
@@ -3,6 +3,12 @@
 module Macros
   # DLME helpers for traject mappings
   module DLME
+    LOC_NS = {
+      srw:    'http://www.loc.gov/zing/srw/',
+      oai_dc: 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+      dc:     'http://purl.org/dc/elements/1.1/'
+    }.freeze
+
     # construct a structured hash using values extracted using traject
     def transform_values(context, hash)
       hash.transform_values do |lambdas|


### PR DESCRIPTION
Removing the NS caused this error: 
```
Error loading configuration file lib/traject/bnf_ideo_config.rb:20 NameError:uninitialized constant NS
lib/traject/bnf_ideo_config.rb:20:in `block in load_config_file'
```
If I remove the NS parameter from extract_xml I get this error:
```
Error loading configuration file lib/traject/bnf_ideo_config.rb:20 ArgumentError:wrong number of arguments (given 1, expected 2..3)
/Users/jtim/Dropbox/DLSS/DLME/dlme/lib/traject/macros/xml.rb:11:in `extract_xml'
lib/traject/bnf_ideo_config.rb:20:in `block in load_config_file'
```
I need help resolving this