### PR TITLE
The application should not be dependent on a database at startup

### DIFF
--- a/config/initializers/translations.rb
+++ b/config/initializers/translations.rb
@@ -2,7 +2,9 @@ require 'i18n/backend/active_record'
 
 Translation = I18n::Backend::ActiveRecord::Translation
 
-if Translation.table_exists?
+# See https://github.com/projectblacklight/spotlight/issues/2133
+# if Translation.table_exists?
+begin
   ##
   # Sets up the new Spotlight Translation backend, backed by ActiveRecord. To
   # turn on the ActiveRecord backend, uncomment the following lines.


### PR DESCRIPTION
This can occur if the app starts up ahead of the database or if we just want to compile assets

See: https://github.com/projectblacklight/spotlight/issues/2133