### PR TITLE
Provide SECRET_KEY_BASE to sidekiq container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - RDS_HOSTNAME=postgres
       - RDS_PORT=5432
       - SOLR_URL=http://solr:8983/solr/dlme
-      - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
+      - SECRET_KEY_BASE
     image: 'suldlss/dlme:latest'
     ports:
       - "3000:3000"
@@ -59,7 +59,10 @@ services:
     depends_on:
       - 'postgres'
       - 'redis'
-    build: .
+    build:
+      context: ./
+      args:
+      - SECRET_KEY_BASE
     command: sidekiq -C config/sidekiq.yml.erb
     volumes:
       - '.:/app'


### PR DESCRIPTION
This is a slapdash fix so that the container will come up.
We shouldn't need to pass the env var to this container once it's not building assets