### PR TITLE
Set path and ID appropriately for redis

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,9 @@
 if defined? Sidekiq
   Sidekiq.configure_server do |config|
-    config.redis = { url: "redis://:#{ENV['REDIS_PASS']}@#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1" }
+    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1", id: "0001" }
   end
 
   Sidekiq.configure_client do |config|
-    config.redis = { url: "redis://:#{ENV['REDIS_PASS']}@#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1" }
+    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1", id: "0001" }
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,9 @@
 if defined? Sidekiq
   Sidekiq.configure_server do |config|
-    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1", id: "0001" }
+    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1" }
   end
 
   Sidekiq.configure_client do |config|
-    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1", id: "0001" }
+    config.redis = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}/1" }
   end
 end


### PR DESCRIPTION
Remove auth (password) from redis config as it is not set in AWS.