### PR TITLE
Sqlite only for dev/test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'rails', '~> 5.2.2'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.3.6'
+
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
@@ -35,6 +34,9 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
+  # Use sqlite3 as the database for Active Record
+  gem 'sqlite3', '~> 1.3.6'
+
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver


### PR DESCRIPTION
This prevents an error when building the sidekiq container:
```
ERROR: Service 'sidekiq' failed to build: The command '/bin/sh -c bundle config build.nokogiri --use-system-libraries     && bundle install --without development test' returned a non-zero code: 5
```