### PR TITLE
Add middleware relative to known middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,6 @@ module Dlme
     # -- all .rb files in that directory are automatically loaded.
 
     config.middleware.use Rack::Attack
-    config.middleware.insert_before(ActionDispatch::Static, FixSnsJsonMiddleware)
+    config.middleware.insert_after(Rack::Attack, FixSnsJsonMiddleware)
   end
 end


### PR DESCRIPTION
ActionDispatch::Static is only used when RAILS_SERVE_STATIC_FILES is set