### PR TITLE
Start redis without a password.

### DIFF
--- a/.env
+++ b/.env
@@ -6,18 +6,9 @@ COMPOSE_PROJECT_NAME=dlme
 # What Rails environment are we in?
 RAILS_ENV=production
 
-# Rails log level.
-#   Accepted values: debug, info, warn, error, fatal, or unknown
-LOG_LEVEL=debug
-
 # You would typically use `rails secret` to generate a secure token. It is
 # critical that you keep this value private in production.
-# SECRET_TOKEN=asecuretokenwouldnormallygohere
 SECRET_KEY_BASE=9483e824b25ea3051e7c94d9513b2b5438b2f913eae0c663207245b43fcba38bca0f1f61ccca970a2b2ba12486125ba34a4719f56b7a8f34d59b005bf09b72b8
-
-# More details about these Puma variables can be found in config/puma.rb.
-# Which address should the Puma app server bind to?
-BIND_ON=0.0.0.0:3000
 
 # Puma supports multiple threads but in development mode you'll want to use 1
 # thread to ensure that you can properly debug your application.
@@ -26,75 +17,22 @@ RAILS_MAX_THREADS=1
 # Puma supports multiple workers but you should stick to 1 worker in dev mode.
 WEB_CONCURRENCY=1
 
-# Requests that exceed 5 seconds will be terminated and dumped to a stacktrace.
-# Feel free to modify this value to fit the needs of your project, but if you
-# have any request that takes more than 5 seconds you probably need to re-think
-# what you are doing 99.99% of the time.
-RACK_TIMEOUT_SERVICE_TIMEOUT=5
-
 # Required by the Postgres Docker image. This sets up the initial database when
 # you first run it.
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=sekret
-
-# The database name will automatically get the Rails environment appended to it
-# such as: orats_base_development or orats_base_production.
 DATABASE_URL=postgresql://postgres:sekret@postgres:5432/dlme?encoding=utf8&pool=5&timeout=5000
 
 REDIS_HOST=redis
 REDIS_PORT=6379
-REDIS_PASS=sekret
-
-# The full Redis URL for the Redis cache.
-REDIS_CACHE_URL=redis://redis:sekret@redis:6379/0
-
-# The namespace used by the Redis cache.
-REDIS_CACHE_NAMESPACE=cache
-
-# Action mailer (e-mail) settings.
-# You will need to enable less secure apps in your Google account if you plan
-# to use GMail as your e-mail SMTP server.
-# You can do that here: https://www.google.com/settings/security/lesssecureapps
-SMTP_ADDRESS=smtp.gmail.com
-SMTP_PORT=587
-SMTP_DOMAIN=gmail.com
-SMTP_USERNAME=you@gmail.com
-SMTP_PASSWORD=yourpassword
-SMTP_AUTH=plain
-SMTP_ENABLE_STARTTLS_AUTO=true
-
-# Not running Docker natively? Replace 'localhost' with your Docker Machine IP
-# address, such as: 192.168.99.100:3000
-ACTION_MAILER_HOST=localhost:3000
-ACTION_MAILER_DEFAULT_FROM=you@gmail.com
-ACTION_MAILER_DEFAULT_TO=you@gmail.com
 
 # Google Analytics universal ID. You should only set this in non-development
 # environments. You wouldn't want to track development mode requests in GA.
 # GOOGLE_ANALYTICS_UA='xxx'
 
-# The full Redis URL for Active Job.
-ACTIVE_JOB_URL=redis://:sekret@redis:6379/0
-REDIS_URL=redis://:sekret@redis:6379/0
+# Used by config/cable.rb
+REDIS_URL=redis://redis:6379/0
+
 # The queue prefix for all Active Jobs. The Rails environment will
 # automatically be added to this value.
 ACTIVE_JOB_QUEUE_PREFIX=dlme:jobs
-
-# The full Redis URL for Action Cable's back-end.
-ACTION_CABLE_BACKEND_URL=redis://redis:sekret@redis:6379/0
-
-# The full WebSocket URL for Action Cable's front-end.
-# Not running Docker natively? Replace 'localhost' with your Docker Machine IP
-# address, such as: ws://192.168.99.100:28080
-ACTION_CABLE_FRONTEND_URL=ws://cable:28080
-
-# Comma separated list of RegExp origins to allow connections from.
-# These values will be converted into a proper RegExp, so omit the / /.
-#
-# Examples:
-#   http:\/\/localhost*
-#   http:\/\/example.*,https:\/\/example.*
-#
-# Not running Docker natively? Replace 'localhost' with your Docker Machine IP
-# address, such as: http:\/\/192.168.99.100*
-ACTION_CABLE_ALLOWED_REQUEST_ORIGINS=http:\/\/localhost*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     image: 'redis:4.0-alpine'
     ports:
       - "6379:6379"
-    command: redis-server --requirepass sekret
+    command: redis-server
     volumes:
       - 'redis:/data'
     networks:


### PR DESCRIPTION
Removed config in .env that we are not using. These came from orats
but we are not using the orats templates