### PR TITLE
Remove an unused config file

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,0 @@
-:queues:
-  - dlme_production_default


### PR DESCRIPTION
The worker container is set to use config/sidekiq.yml.erb but there
was also a config/sidekiq.yml which was confusing.