### PR TITLE
Add link to terraform for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ docker build . -f docker/Dockerfile -t suldlss/dlme:latest --build-arg SECRET_KE
 docker push suldlss/dlme:latest
 ```
 
+#### Submit a pull request to update the container in AWS
+
+[Follow the README instructions in terraform.](https://github.com/sul-dlss/terraform-aws/tree/master/organizations/production/dlme)
 
 ## Converting files
 All files must first be converted to the intermediate representation (IR) before they can be imported. This is done by the https://github.com/sul-dlss/dlme-transform repository.


### PR DESCRIPTION
Completes #500 with a link to the terraform organization readme. The documentation has been placed there as it involves linking to private code.