### PR TITLE
Add download of p12 key from S3 in spotlight_initializer

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 # ==> User model
 # Note that your chosen model must include Spotlight::User mixin
 # Spotlight::Engine.config.user_class = '::User'
@@ -49,9 +51,17 @@ Spotlight::Engine.config.default_autocomplete_params = { qf: 'id^1000 cho_title_
 # Spotlight::Engine.config.featured_image_square_size = [400, 400]
 
 # ==> Google Analytics integration
+if Settings.analytics.pkcs12_key && Settings.analytics.pkcs12_key_path
+  File.open(Settings.analytics.pkcs12_key_path, "wb") do |file|
+    open(Settings.analytics.pkcs12_key, "rb") do |read_file|
+      file.write(read_file.read)
+    end
+  end
+end
+
 # Spotlight::Engine.config.analytics_provider = nil
-# Spotlight::Engine.config.ga_pkcs12_key_path = nil
+Spotlight::Engine.config.ga_pkcs12_key_path = Settings.analytics.pkcs12_key_path
 Spotlight::Engine.config.ga_web_property_id = Settings.analytics.web_property_id
-# Spotlight::Engine.config.ga_email = nil
+Spotlight::Engine.config.ga_email = Settings.analytics.email
 # Spotlight::Engine.config.ga_analytics_options = {}
 # Spotlight::Engine.config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,8 +2,13 @@ application:
   default_host: ~
   default_from: ~
 
+# pkcs12_key: URI to key file location in S3
+# pkcs12_key_path: Path that will be used to store the PKCS12 Key file
 analytics:
   web_property_id: ~
+  pkcs12_key: ~
+  pkcs12_key_path: ~
+  email: ~
 
 contact:
   email: ~


### PR DESCRIPTION
Since we are running this in a container, we want to avoid including the PKCS12 key for google analytics in the public image. This allows us to pass a path to create the file and an S3 path to download the file in ENV variables and then grab the key file during initialization.