### PR TITLE
fix badge typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[[![CircleCI](https://circleci.com/gh/sul-dlss/dlme.svg?style=svg)](https://circleci.com/gh/sul-dlss/dlme)
+[![CircleCI](https://circleci.com/gh/sul-dlss/dlme.svg?style=svg)](https://circleci.com/gh/sul-dlss/dlme)
 [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/dlme/badge.svg)](https://coveralls.io/github/sul-dlss/dlme)
 
 # Digital Library of the Middle East


### PR DESCRIPTION
d'oh - typo.

Question:  circleci configs don't run tests on master, but that means coveralls badge is a bit wonky.  Should we run tests on master?