### PR TITLE
Remove unused platforms from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem 'sqlite3', '~> 1.3.6'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'byebug'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'coveralls', require: false
@@ -69,9 +69,6 @@ group :production do
 end
 
 gem 'aws-sdk-sns'
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'blacklight-spotlight', '~> 2.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.6)
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 


### PR DESCRIPTION
We do not deploy to Windows or JRuby environments, so remove these unnecessary lines that break aliases/functions wrapped around `bundle`.