### PR TITLE
Make sure transform_results view always defines links

### DIFF
--- a/app/views/transform_results/show.json.jbuilder
+++ b/app/views/transform_results/show.json.jbuilder
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+empty_links = {}
+
 json.links do
   json.prev path_to_prev_page(@results) if @results.prev_page
   json.next path_to_next_page(@results) if @results.next_page
+  # Prevents the `links` object from being `undefined` if neither conditions above are true
+  json.merge!(empty_links)
 end
 
 json.data @results

--- a/spec/requests/transform_result_spec.rb
+++ b/spec/requests/transform_result_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'transform results', type: :request do
   context 'when signed in' do
     let(:curator) { create(:exhibit_curator) }
+    let(:body) { JSON.parse(response.body).with_indifferent_access }
 
     before do
       sign_in curator
@@ -13,6 +14,11 @@ RSpec.describe 'transform results', type: :request do
     it 'shows transform results' do
       get '/transform_result'
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'includes navigation links' do
+      get '/transform_result'
+      expect(body[:links]).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Fixes #576

## Why was this change made?

This commit makes sure the transform_results JSON *always* contains the `links` object. Without this change, `data.links` is undefined when the page initially loads which causes a JavaScript error that prevents the transformation results from rendering

## Was the documentation (README, API, wiki, ...) updated?

n/a