### PR TITLE
Validate that S3 Fetch URL contains no duplicate identifiers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
     form:
       title: 'DLME S3 Fetch'
       add_item: 'Fetch'
+      error: 'JSON contained duplicate identifiers'
   s3_delete:
     new:
       add_item: Delete Items

--- a/spec/controllers/s3_harvester_controller_spec.rb
+++ b/spec/controllers/s3_harvester_controller_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe S3HarvesterController do
-  let(:exhibit) { create(:exhibit) }
   let(:curator) { create(:exhibit_curator, exhibit: exhibit) }
+  let(:exhibit) { create(:exhibit) }
+  let(:spotlight) { Spotlight::Engine.routes.url_helpers }
   let(:url) { 'http://s3/mybucket/myfile.json' }
 
   before do
@@ -12,15 +13,29 @@ RSpec.describe S3HarvesterController do
   end
 
   describe 'POST create' do
+    let(:body) { "{\"id\":\"one\"}\n{\"id\":\"two\"}" }
+
     before do
+      allow(controller).to receive(:body).and_return(body)
       allow(FetchResourcesJob).to receive(:perform_later)
     end
 
     it 'submits a job' do
       post :create, params: { exhibit_id: exhibit.slug, url: url }
       expect(FetchResourcesJob).to have_received(:perform_later).with(url, exhibit)
-      expect(flash[:notice]).to be_present
-      expect(response).to be_redirect
+      expect(flash[:notice]).to eq('Queued for processing.')
+      expect(response).to redirect_to(spotlight.admin_exhibit_catalog_path(exhibit))
+    end
+
+    context 'when content at url contains duplicate identifiers' do
+      let(:body) { "{\"id\":\"one\"}\n{\"id\":\"one\"}" }
+
+      it 'redirects with an error flash message' do
+        post :create, params: { exhibit_id: exhibit.slug, url: url }
+        expect(FetchResourcesJob).not_to have_received(:perform_later)
+        expect(flash[:error]).to eq('JSON contained duplicate identifiers')
+        expect(response).to redirect_to(spotlight.new_exhibit_resource_path(exhibit))
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes sul-dlss/dlme-transform#158

## Why was this change made?

This lets users know up front that their transformation batch contains duplicate rows, which may lead to a surprising count of items in the exhibit. Ran this idea by Jacob and he approves of the approach.

## Was the documentation (README, API, wiki, ...) updated?

No.