### PR TITLE
Remove vestiges of dlme-traject repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sns \
 
 Note that this will need to be repeated ever time localstack is started.
 
-Make sure you have cloned the [dlme-metadata](https://github.com/sul-dlss/dlme-metadata), [dlme-transform](https://github.com/sul-dlss/dlme-transform), and [dlme-traject](https://github.com/sul-dlss/dlme-traject) repositories in sibling directories to the `dlme` directory.
+Make sure you have cloned the [dlme-metadata](https://github.com/sul-dlss/dlme-metadata) and [dlme-transform](https://github.com/sul-dlss/dlme-transform) repositories in sibling directories to the `dlme` directory.
 
 To perform a local transform that will write to localstack S3 and send a notification to localstack SNS:
 
@@ -95,10 +95,8 @@ docker run --rm -e S3_BUCKET=dlme-transform \
                 -e SNS_ENDPOINT_URL=http://localhost:4575 \
                 -e S3_ENDPOINT_URL=http://localhost:4572 \
                 -e S3_BASE_URL=http://localstack:4572 \
-                -e SKIP_FETCH_CONFIG=true \
                 -e SKIP_FETCH_DATA=true \
                 -v $(pwd)/../dlme-transform:/opt/traject \
-                -v $(pwd)/../dlme-traject:/opt/traject/config \
                 -v $(pwd)/../dlme-metadata:/opt/traject/data \
                 -v $(pwd)/tmp/output:/opt/traject/output \
                 --network="host" \

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Data Documentation for the Digital Library of the Middle East
 
-For data providers, start by reading our [Information for Data Providers](providers.md) page. 
+For data providers, start by reading our [Information for Data Providers](providers.md) page.
 
 ## Dataflow through the Application
 
@@ -14,8 +14,8 @@ At present, this diagram represents how data travels from being queued up for in
 * [SSH into the harvest VM](https://github.com/sul-dlss/dlme-harvest)
 * Run any needed harvests
 * Commit harvested records and push to `dlme-metadata` Github repo
-* [Add information to the JSON configuration for traject](https://github.com/sul-dlss/dlme-traject/blob/master/metadata_mapping.json)
-* [Write a traject mapping for new source(s)](https://github.com/sul-dlss/dlme-traject)
+* [Add information to the JSON configuration for traject](https://github.com/sul-dlss/dlme-transform/blob/master/config/metadata_mapping.json)
+* [Write a traject mapping for new source(s)](https://github.com/sul-dlss/dlme-transform/tree/master/traject_configs)
 * Test and debug traject mapping locally
 * Add any changes to the translation maps if needed (in `dlme-transform`)
 * Commit configuration and traject mapping to a new branch and create a pull request
@@ -24,13 +24,13 @@ At present, this diagram represents how data travels from being queued up for in
   * Input the file path for records to map (or leave blank to run all) and click start button
   * Check status of transform in site administration to see if it succeeded or failed
   * If it failed, look at error message and diagnose locally or ask team for assistance
-  * If it succeeded (the number of transformed records should match the number of harvested records) get link to the file in S3 for the transformation results 
+  * If it succeeded (the number of transformed records should match the number of harvested records) get link to the file in S3 for the transformation results
   * Go to Exhibit dashboard -> Items and click "Add items"
   * Click "DLME S3 Fetch" and paste link into form, then click "Fetch"
   * Confirm the number of records match what is expected
   * Once reindexing finishes, look at new records to test and to confirm they look right
   * Undertake any needed review with lead curator and data providers
-  
+
 * In production:
   * Sign into the https://spotlight.dev.dlmenetwork.org/ and go to Exhibit dashboard -> Items
   * Click "Add items"


### PR DESCRIPTION
## Why was this change made?

To remove outdated docs.

## Was the documentation (README, API, wiki, ...) updated?

Yes.