### PR TITLE
Fix bug in FetchResourcesJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ AllCops:
     - 'config/**/*'
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
+    - 'tmp/**/*'
+    - 'postgres-data/**/*'
 
 Rails:
   Enabled: true

--- a/app/jobs/fetch_resources_job.rb
+++ b/app/jobs/fetch_resources_job.rb
@@ -9,14 +9,14 @@ class FetchResourcesJob < ApplicationJob
 
     resource = resp.body.split("\n")
     resource.each_with_index do |item, index|
-      create_or_update_resource(item, exhibit, index)
+      create_or_update_resource(item, exhibit, index, url)
     end
     logger.info("#{resource.count} records were created from #{url}.")
   end
 
   private
 
-  def create_or_update_resource(item, exhibit, index)
+  def create_or_update_resource(item, exhibit, index, url)
     json = JSON.parse(item)
     resource = DlmeJson.find_or_initialize_by(url: json['id'], exhibit: exhibit)
     resource.data = { json: item }


### PR DESCRIPTION
## Why was this change made?

`url` was not defined FetchResourcesJob#create_or_update_resource and this code path was not tested. Now we test it and `url` is defined.

## Was the documentation (README, API, wiki, ...) updated?

no