### PR TITLE
Handle multilingual tokenized fields

### DIFF
--- a/spec/fixtures/json/iiif-single-image.json
+++ b/spec/fixtures/json/iiif-single-image.json
@@ -22,6 +22,7 @@
   "agg_provider": "Princeton University",
   "agg_provider_country": "United States of America",
   "cho_contributor": ["فاتن حمامة", "محمود ياسين", "فريد شوقي", "بركات"],
+  "cho_creator": ["Jane Q. Doe", "John X. Doe"],
   "cho_coverage": ["Egypt"],
   "cho_date": "1977",
   "cho_edm_type": "Image",
@@ -31,6 +32,6 @@
   "cho_is_part_of": "http://pudl.princeton.edu/collections/pudl0100",
   "cho_language": "Arabic",
   "cho_spatial": ["Egypt"],
-  "cho_title": "افواه و ارانب",
+  "cho_title": {"ar-Arab": ["افواه و ارانب"]},
   "cho_type": "Posters"
 }

--- a/spec/resource_builders/dlme_json_resource_builder_spec.rb
+++ b/spec/resource_builders/dlme_json_resource_builder_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DlmeJsonResourceBuilder do
         'cho_is_part_of_ssim' => 'http://pudl.princeton.edu/collections/pudl0100',
         'cho_language_ssim' => 'Arabic',
         'cho_spatial_ssim' => ['Egypt'],
-        'cho_title_ssim' => 'افواه و ارانب',
+        'cho_title.ar-Arab_ssim' => ['افواه و ارانب'],
         'cho_type_ssim' => 'Posters',
         :id => 'princeton_rj4305881',
         'agg_is_shown_at.wr_id_ssim' => 'http://arks.princeton.edu/ark:/88435/rj4305881',
@@ -46,7 +46,7 @@ RSpec.describe DlmeJsonResourceBuilder do
       { 'cho_contributor_tsim' => ['فاتن حمامة', 'محمود ياسين', 'فريد شوقي', 'بركات'],
         'cho_coverage_tsim' => ['Egypt'],
         'cho_spatial_tsim' => ['Egypt'],
-        'cho_title_tsim' => 'افواه و ارانب' }
+        'cho_title.ar-Arab_tsim' => ['افواه و ارانب'] }
     end
 
     it 'adds the original source record' do
@@ -71,13 +71,14 @@ RSpec.describe DlmeJsonResourceBuilder do
       }.to_json)
     end
 
-    it 'adds sortable fields for title' do
-      expect(solr_doc).to include 'sortable_cho_title_ssi' => 'افواه و ارانب'
+    it 'adds sortable fields' do
+      expect(solr_doc).to include('sortable_cho_title.ar-Arab_ssi' => 'افواه و ارانب')
+      expect(solr_doc).to include('sortable_cho_creator_ssi' => 'Jane Q. Doe')
     end
 
     it 'includes metadata context fields' do
-      expect(solr_doc).to include 'traject_context_command_line.filename_ssim' => fixture_file_path,
-                                  'traject_context_source_ssim' => 'dlme_json_resource_spec'
+      expect(solr_doc).to include('traject_context_command_line.filename_ssim' => fixture_file_path,
+                                  'traject_context_source_ssim' => 'dlme_json_resource_spec')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

An additional wrinkle uncovered when dealing with multilingual fields: sending a hash along in a tokenized field makes Solr unhappy. This PR adds awareness of multilingual fields (using the IIIF-y language hash), and reaches into these hashes to construct lang-specific Solr fields with arrays as values. Also, make sure the derived sortable field logic can deal with these same fields.

## Was the documentation (README, API, wiki, ...) updated?

no.