### PR TITLE
Add JS webdrivers + Add browser integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.6.3-stretch-node
+    - image: circleci/ruby:2.6.3-stretch-node-browsers
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'solr_wrapper'
+  gem 'webdrivers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -551,6 +551,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.3)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -611,6 +615,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 BUNDLED WITH
    2.0.2

--- a/spec/features/admin_menu_spec.rb
+++ b/spec/features/admin_menu_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This is primarily a stub spec to validate we are executing javascript
+# until we have more thorough browser integration tests for other needs
+RSpec.describe 'Admin menu', type: :feature, js: true do
+  let(:exhibit) { create(:exhibit) }
+  let(:curator) { create(:exhibit_curator, exhibit: exhibit) }
+
+  before { login_as curator }
+
+  it 'has a customized togglable menu that includes a "Transform data" link' do
+    visit root_path
+
+    within '#user-util-collapse' do
+      expect(page).not_to have_css('li a', text: 'Transform data', visible: true)
+      click_link curator.email
+      expect(page).to have_css('li a', text: 'Transform data', visible: true)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require_relative 'support/controller_level_helpers'
+require 'selenium-webdriver'
+
+Capybara.javascript_driver = :selenium_chrome_headless
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Closes #613 

## Why was this change made?
To add the ability to more closely test browser behavior in anticipation of some upcoming work around RTL.

## Was the documentation (README, API, wiki, ...) updated?
These tests will run alongside other tests as well as follows our existing conventions, so hopefully no documentation should be required.