### PR TITLE
Clean and update the solr configurations

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -3,231 +3,76 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SchemaXml,
      as well as the default schema file included with Solr -->
-  
+
   <uniqueKey>id</uniqueKey>
-  
+
   <fields>
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="_version_" type="long"     indexed="true"  stored="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-    
-    <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
-    <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
-    <field name="original_pid_tesim" type="pid_text" stored="true" indexed="true" multiValued="true"/>
 
     <field name="cho_title_ng" type="text_en_ng" stored="false" indexed="true" multiValued="true"/>
     <field name="id_ng"         type="text_en_ng" stored="false" indexed="true" multiValued="false"/>
 
-   <dynamicField name="*_bbox"   type="location_rpt" stored="true" indexed="true"/>
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- text (_t...) -->
-<!--
-    <dynamicField name="*_ti" type="text" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_tim" type="text" stored="false" indexed="true" multiValued="true"/>
--->
+
     <dynamicField name="*_ts" type="text" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
-<!--
-    <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
--->
-    <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- exact-ish text (_exact_t...); exact matching of whitespace tokenized terms -->
     <dynamicField name="*_exact_ts" type="text_ws" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_exact_tsm" type="text_ws" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_exact_tsi" type="text_ws" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_exact_tsim" type="text_ws" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_exact_tsiv" type="text_ws" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_exact_tsimv" type="text_ws" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <dynamicField name="*_fuzzy_tsim" type="text_fuzzy" stored="true" indexed="true" multiValued="true"/>
 
     <!-- English text (_te...) -->
-<!--
-    <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
--->
     <dynamicField name="*_tes" type="text_en" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_tesm" type="text_en" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tesi" type="text_en" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tesim" type="text_en" stored="true" indexed="true" multiValued="true"/>
-<!--
-    <dynamicField name="*_teiv" type="text_en" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
--->
-    <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- Arabic text (_tar...) -->
     <dynamicField name="*_tars" type="text_ar" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_tarsm" type="text_ar" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tarsi" type="text_ar" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tarsim" type="text_ar" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_tarsiv" type="text_ar" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tarsimv" type="text_ar" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- Persian text (_tfa...) -->
     <dynamicField name="*_tfas" type="text_fa" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_tfasm" type="text_fa" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tfasi" type="text_fa" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tfasim" type="text_fa" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_tfasiv" type="text_fa" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tfasimv" type="text_fa" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- Turkish text (_ttr...) -->
     <dynamicField name="*_ttrs" type="text_tr" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ttrsm" type="text_tr" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ttrsi" type="text_tr" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ttrsim" type="text_tr" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_ttrsiv" type="text_tr" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_ttrsimv" type="text_tr" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- string (_s...) -->
-<!--
-    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
--->
     <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
-<!--
-    <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
--->
-    
+
     <!-- integer (_i...) -->
-<!--
-    <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
--->
     <dynamicField name="*_is" type="int" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- trie integer (_it...) (for faster range queries) -->
-<!--
-    <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_its" type="tint" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- date (_dt...) -->
-    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
-         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
-<!--
-    <dynamicField name="*_dti" type="date" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dtim" type="date" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_dts" type="date" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- trie date (_dtt...) (for faster range queries) -->
-<!--
-    <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_dtts" type="tdate" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- long (_l...) -->
-<!--
-    <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_ls" type="long" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- trie long (_lt...) (for faster range queries) -->
-<!--
-    <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_lts" type="tlong" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- double (_db...) -->
-<!--
-    <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_dbs" type="double" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- trie double (_dbt...) (for faster range queries) -->
-<!--
-    <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_dbts" type="tdouble" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- float (_f...) -->
-<!--
-    <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_fs" type="float" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
-    
-    <!-- trie float (_ft...) (for faster range queries) -->
-<!--
-    <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_fts" type="tfloat" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- boolean (_b...) -->
-<!--
-    <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
--->
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
-    <!-- Type used to index the lat and lon components for the "location" FieldType -->
-<!--
-    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
--->
-
-    <!-- location (_ll...) -->
-<!--
-    <dynamicField name="*_lli" type="location" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_llim" type="location" stored="false" indexed="true" multiValued="true"/>
--->
-    <dynamicField name="*_lls" type="location" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_llsm" type="location" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false"/>
-    <dynamicField name="*_llsim" type="location" stored="true" indexed="true" multiValued="true"/>
 
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-
-
   </fields>
 
 
@@ -263,52 +108,18 @@
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
-    <!-- trie numeric field types for faster range queries -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
-    <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
-    <!-- This point type indexes the coordinates as separate fields (subFields)
-      If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
-      subFieldSuffix is defined, that is used to create the subFields.
-      Example: if subFieldType="double", then the coordinates would be
-        indexed in fields myloc_0___double,myloc_1___double.
-      Example: if subFieldSuffix="_d" then the coordinates would be indexed
-        in fields myloc_0_d,myloc_1_d
-      The subFields are an implementation detail of the fieldType, and end
-      users normally should not need to know about them.
-     -->
-    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
-    <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
-      For more information about this and other Spatial fields new to Solr 4, see:
-      http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
-    -->
-    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-    
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -316,7 +127,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -324,16 +135,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
-    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
-    <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.TrimFilterFactory" />
-      </analyzer>
-    </fieldtype>
-    
+
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -371,7 +173,7 @@
 
     <!-- Turkish -->
     <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
@@ -409,33 +211,5 @@
         </filter>
       </analyzer>
     </fieldType>
-
-    <fieldType name="pid_text" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
-        
-    <!-- queries for paths match documents at that path, or in descendent paths -->
-    <fieldType name="descendent_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-    </fieldType>
-    
-    <!-- queries for paths match documents at that path, or in ancestor paths -->
-    <fieldType name="ancestor_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-    </fieldType>
-    
   </types>
-  
 </schema>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -3,10 +3,10 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
      as well as the default solrconfig file included with Solr -->
-  
+
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
-  
-  <luceneMatchVersion>6.6.0</luceneMatchVersion>
+
+  <luceneMatchVersion>8.2.0</luceneMatchVersion>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
 


### PR DESCRIPTION
Many dynamic field variants in the schema are commented out or unused. Some of the configurations are considered deprecated and/or have new defaults in current versions of Solr. This PR removes those to try to get a better picture of what's currently happening (and if we discover we need them, they're easy enough to add).

Also, bump thee `luceneMatchVersion` to get some of the relevancy ranking changes and other defaults, so we deal with them now instead of after putting extensive effort into relevancy tuning.