### PR TITLE
Don't override spotlight's exhibit CRUD routes with application routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :exhibits do
+  resources :exhibits, only: [] do
     resources :dlme_jsons if Settings.feature_flags.allow_json_upload
     resource :s3_harvester, controller: :"s3_harvester", only: [:create]
     resource :s3_delete, controller: :s3_delete, only: [:new, :create]


### PR DESCRIPTION
This should fix the 404 from https://spotlight.stage.dlmenetwork.org/exhibits/edit (and possibly similar errors).