### PR TITLE
Also index multilingual fields into a common field

### DIFF
--- a/app/resource_builders/dlme_json_resource_builder.rb
+++ b/app/resource_builders/dlme_json_resource_builder.rb
@@ -28,6 +28,8 @@ class DlmeJsonResourceBuilder < Spotlight::SolrDocumentBuilder
         # Handle hashes specially because if a hash slips through to Solr, Solr
         # gets unhappy and will return a 400 error.
         if source[key].is_a?(Hash)
+          sink["#{key}_tsim"] = source[key].values.flatten
+
           source[key].each do |language_code, values|
             sink["#{key}.#{language_code}_tsim"] = values
             sink["sortable_#{key}.#{language_code}_ssi"] = values.first
@@ -52,6 +54,7 @@ class DlmeJsonResourceBuilder < Spotlight::SolrDocumentBuilder
       case value
       when Hash
         transform_to_untokenized_solr_fields(value, sink: sink, prefix: "#{key}.")
+        sink["#{prefix}#{key}_ssim"] = value.values.flatten
       when Array
         sink["#{prefix}#{key}_ssim"] = if value.any? { |x| x.is_a? Hash }
                                          value.map(&:to_json)

--- a/spec/resource_builders/dlme_json_resource_builder_spec.rb
+++ b/spec/resource_builders/dlme_json_resource_builder_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe DlmeJsonResourceBuilder do
         'cho_is_part_of_ssim' => 'http://pudl.princeton.edu/collections/pudl0100',
         'cho_language_ssim' => 'Arabic',
         'cho_spatial_ssim' => ['Egypt'],
+        'cho_title_ssim' => ['افواه و ارانب'],
         'cho_title.ar-Arab_ssim' => ['افواه و ارانب'],
         'cho_type_ssim' => 'Posters',
         :id => 'princeton_rj4305881',
@@ -46,6 +47,7 @@ RSpec.describe DlmeJsonResourceBuilder do
       { 'cho_contributor_tsim' => ['فاتن حمامة', 'محمود ياسين', 'فريد شوقي', 'بركات'],
         'cho_coverage_tsim' => ['Egypt'],
         'cho_spatial_tsim' => ['Egypt'],
+        'cho_title_tsim' => ['افواه و ارانب'],
         'cho_title.ar-Arab_tsim' => ['افواه و ارانب'] }
     end
 


### PR DESCRIPTION
## Why was this change made?

In order to keep the app functional while fields are being transformed into language-tagged fields, keep on indexing them into the same old fields. This also is useful for some analytics and curation queries (e.g. show me all the things without titles) 

## Was the documentation (README, API, wiki, ...) updated?
