### PR TITLE
Add initial (basic) support for multilingual fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -31,15 +31,28 @@ class CatalogController < ApplicationController
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 
-    # solr field configuration for search results/index views
-    config.index.title_field = 'cho_title_ssim'
+    locale_encoded_fields = lambda do |field_prefix, suffix = 'ssim'|
+      (Settings.acceptable_bcp47_codes << 'none').map do |code|
+        [code, "#{field_prefix}.#{code}_#{suffix}"]
+      end.to_h
+    end
+
+    config.index.title_field = locale_encoded_fields.call('cho_title').values
     config.index.thumbnail_field = 'agg_preview.wr_id_ssim'
     config.index.default_thumbnail = 'default.png'
 
-    config.add_index_field 'title', field: 'cho_title_ssim'
+    locale_encoded_fields.call('cho_title').each do |code, field|
+      config.add_index_field "title (#{code})", field: field
+    end
+
     config.add_index_field 'date', field: 'cho_date_ssim'
-    config.add_index_field 'holding institution', field: 'agg_data_provider_ssim'
-    config.add_index_field 'source institution', field: 'agg_provider_ssim'
+    locale_encoded_fields.call('agg_data_provider').each do |code, field|
+      config.add_index_field "holding institution (#{code})", field: field
+    end
+    locale_encoded_fields.call('agg_provider').each do |code, field|
+      config.add_index_field "source institution (#{code})", field: field
+    end
+
     config.add_index_field 'extent', field: 'cho_extent_ssim'
     config.add_index_field 'creator', field: 'cho_creator_ssim'
     config.add_index_field 'description',
@@ -104,10 +117,19 @@ class CatalogController < ApplicationController
     # handler defaults, or have no facets.
     config.add_facet_fields_to_solr_request!
 
-    config.add_show_field 'title', field: 'cho_title_ssim'
+    locale_encoded_fields.call('cho_title').each do |code, field|
+      config.add_show_field "title (#{code})", field: field
+    end
     config.add_show_field 'date', field: 'cho_date_ssim'
-    config.add_show_field 'holding_institution', field: 'agg_data_provider_ssim'
-    config.add_show_field 'source_institution', field: 'agg_provider_ssim'
+
+    locale_encoded_fields.call('agg_data_provider').each do |code, field|
+      config.add_show_field "holding_institution (#{code})", field: field
+    end
+
+    locale_encoded_fields.call('agg_provider').each do |code, field|
+      config.add_show_field "source_institution (#{code})", field: field
+    end
+
     config.add_show_field 'extent', field: 'cho_extent_ssim'
     config.add_show_field 'alternative', field: 'cho_alternative_ssim'
     config.add_show_field 'contributor', field: 'cho_contributor_ssim'
@@ -143,7 +165,9 @@ class CatalogController < ApplicationController
     config.add_show_field '__source', field: '__source_ssim'
     config.add_show_field 'agg_dc_rights', field: 'agg_dc_rights_ssim'
     config.add_show_field 'agg_edm_rights', field: 'agg_edm_rights_ssim', autolink: true
-    config.add_show_field 'agg_provider', field: 'agg_provider_ssim'
+    locale_encoded_fields.call('agg_provider').each do |code, field|
+      config.add_show_field "agg_provider institution (#{code})", field: field
+    end
     config.add_show_field 'agg_is_shown_at', field: 'agg_is_shown_at.wr_id_ssim', autolink: true
 
     config.add_search_field 'all_fields', label: 'Everything'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -80,10 +80,14 @@ class CatalogController < ApplicationController
     config.add_facet_field 'contributor', field: 'cho_contributor_ssim', limit: true
     config.add_facet_field 'medium',      field: 'cho_medium_ssim', limit: true
     config.add_facet_field 'dc_rights',   field: 'cho_dc_rights_ssim', limit: true
-    config.add_facet_field 'holding_institution', field: 'agg_data_provider_ssim', limit: true
+    locale_encoded_fields.call('agg_data_provider').each do |code, field|
+      config.add_facet_field "holding_institution (#{code})", field: field, limit: true
+    end
 
     # "administrative"-like facets
-    config.add_facet_field 'source_institution', field: 'agg_provider_ssim', limit: true
+    locale_encoded_fields.call('agg_provider').each do |code, field|
+      config.add_facet_field "source_institution (#{code})", field: field, limit: true
+    end
     config.add_facet_field 'thumbnail', query: {
       yes: { label: 'Yes', fq: 'agg_preview.wr_id_ssim:[* TO *]' },
       no: { label: 'No', fq: '-agg_preview.wr_id_ssim:[* TO *]' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,13 @@ allow_robots: false
 
 feature_flags:
   allow_json_upload: false
+
+acceptable_bcp47_codes:
+  - ar-Arab
+  - ar-Latn
+  - en
+  - fa-Arab
+  - fa-Latn
+  - fr
+  - tr-Arab
+  - tr-Latn


### PR DESCRIPTION
Part of #630 

## Why was this change made?
So we can begin to see the multilingual content that was indexed transformed/indexed before #589 is ready to be worked on (which will be the more complex logic of what is displayed when certain locales are chosen).

## Was the documentation (README, API, wiki, ...) updated?
n/a

Note: This is more-or-less just a stop gap so that we can render the multilingual data that is available.  There is work going on both in DLME (for Empty values faceting purposes) and upstream in Blacklight (for features that will support multilingual field rendering) that will likely supersede this code in the long run

## Before
<img width="287" alt="facets-before" src="https://user-images.githubusercontent.com/96776/68258147-9c3a3000-ffea-11e9-99d1-b8c3334886d5.png">

<img width="880" alt="result-record-before" src="https://user-images.githubusercontent.com/96776/68258144-9c3a3000-ffea-11e9-94a3-4496a37c19b7.png">


## After 
<img width="280" alt="facets-after" src="https://user-images.githubusercontent.com/96776/68258148-9c3a3000-ffea-11e9-9223-0c1402382af4.png">

<img width="969" alt="result-record-after" src="https://user-images.githubusercontent.com/96776/68258149-9cd2c680-ffea-11e9-8384-a991b65bad28.png">


