### PR TITLE
Install git into the app containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --update --no-cache \
       libxslt-dev \
       postgresql-dev \
       sqlite-dev \
-      yarn
+      yarn \
+      git
 
 LABEL maintainer="Aaron Collier <aaron.collier@stanford.edu>"
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -19,6 +19,7 @@ RUN apk add --no-cache build-base \
                        gmp-dev \
                        tzdata \
                        sqlite-dev \
+                       git
     && gem install bundler
 
 RUN apk add --no-cache git


### PR DESCRIPTION
## Why was this change made?

Without this, the build image step fails with:
> sh: git: not found

after we started pointing our app at the spotlight master branch