### PR TITLE
Add a temporary hack to make the docker build process happy with…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,13 @@ RUN apk --no-cache add --virtual build-dependencies \
 
 COPY . .
 
+# Run this again while we're point at spotlight master, otherwise bundler complains:
+# > The git source https://github.com/projectblacklight/spotlight.git is not yet checked out.
+RUN apk --no-cache add --virtual build-dependencies \
+  build-base \
+  && bundle install --without ${BUNDLE_WITHOUT} \
+  && apk del build-dependencies
+
 RUN rake assets:precompile
 # Start the server by default, listening for all connections
 CMD puma -C config/puma.rb

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -34,5 +34,11 @@ RUN bundle config build.nokogiri --use-system-libraries \
     && bundle install --without ${BUNDLE_WITHOUT}
 
 COPY . .
+
+# Run this again while we're point at spotlight master, otherwise bundler complains:
+# > The git source https://github.com/projectblacklight/spotlight.git is not yet checked out.
+RUN bundle config build.nokogiri --use-system-libraries \
+    && bundle install --without ${BUNDLE_WITHOUT}
+
 # Start the server by default, listening for all connections
 CMD sidekiq -C config/sidekiq.yml.erb


### PR DESCRIPTION
…ting at spotlight master

## Why was this change made?

Otherwise bundler complains:
> The git source https://github.com/projectblacklight/spotlight.git is not yet checked out.

Something about the `COPY . .` directive is making bundler lose its mind; fortunately running bundle install again is pretty fast.


## Was the documentation (README, API, wiki, ...) updated?
