### PR TITLE
Add a missing trailing slash to the worker dockerfile

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -19,7 +19,7 @@ RUN apk add --no-cache build-base \
                        gmp-dev \
                        tzdata \
                        sqlite-dev \
-                       git
+                       git \
     && gem install bundler
 
 RUN apk add --no-cache git


### PR DESCRIPTION
## Why was this change made?
```
Error response from daemon: Dockerfile parse error line 23: unknown instruction: &&
Exited with code 1
```

## Was the documentation (README, API, wiki, ...) updated?
