### PR TITLE
Update i18n fallbacks config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
## Why was this change made?
The way that i18n fallbacks are configured was changed in i18n [v1.1.0](https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0).

## Was the documentation (README, API, wiki, ...) updated?
No.