### PR TITLE
Use settings to configure the action mailer options (e.g. from) and url options (e.g. host)

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: Settings.application.default_from
   layout 'mailer'
 end

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,0 +1,9 @@
+if defined?(Settings) && Settings.action_mailer
+  if Settings.action_mailer.default_url_options
+    Dlme::Application.config.action_mailer.default_url_options = Settings.action_mailer.default_url_options.try(:to_h) || {}
+  end
+
+  if Settings.action_mailer.default_options
+    Dlme::Application.config.action_mailer.default_options = Settings.action_mailer.default_options.try(:to_h) || {}
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -13,7 +13,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = Settings.application.default_from
+  config.mailer_sender = Settings.action_mailer.try(:[], :default_options).try(:[], :from)
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,11 @@
 application:
   default_host: ~
-  default_from: ~
+
+action_mailer:
+  default_options:
+    from: ~
+  default_url_options:
+    host: ~
 
 # pkcs12_key: URI to key file location in S3
 # pkcs12_key_path: Path that will be used to store the PKCS12 Key file


### PR DESCRIPTION
This is the same pattern we're using in exhibits and it seems useful (and a little more flexible than the current one.) This will also require some terraform work to set the environment variables for the deploy.

Part of #626 