### PR TITLE
Migrate user_util_links markup to bootstrap 4

### DIFF
--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -39,13 +39,13 @@
       </ul>
     </li>
   <% else %>
-    <li class="dropdown-item">
-      <%= link_to t('spotlight.header_links.login'), main_app.new_user_session_path %>
+    <li class="nav-item">
+      <%= link_to t('spotlight.header_links.login'), main_app.new_user_session_path, class: 'nav-link' %>
     </li>
   <% end %>
   <% if current_exhibit and show_contact_form? %>
-    <li class="dropdown-item">
-      <%= link_to t('spotlight.header_links.contact'), spotlight.new_exhibit_contact_form_path(current_exhibit), data: {behavior: 'contact-link', target: 'report-problem-form' } %>
+    <li class="nav-item">
+      <%= link_to t('spotlight.header_links.contact'), spotlight.new_exhibit_contact_form_path(current_exhibit), class: 'nav-link', data: {behavior: 'contact-link', target: 'report-problem-form' } %>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Before:
<img width="237" alt="Screen Shot 2019-11-07 at 10 40 36" src="https://user-images.githubusercontent.com/111218/68417319-0c5fc780-014b-11ea-8780-084d88225b1b.png">

After:
<img width="184" alt="Screen Shot 2019-11-07 at 10 40 53" src="https://user-images.githubusercontent.com/111218/68417342-15509900-014b-11ea-8045-d240dff11547.png">
