### PR TITLE
Display IR + solr doc debug info  on the show page for exhibit a…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,6 +14,7 @@ class CatalogController < ApplicationController
 
     config.show.oembed_field = :"agg_is_shown_at.wr_id_ssim"
     config.show.partials.insert(1, :viewer)
+    config.show.partials.append(:ir_view)
 
     config.view.list.partials = %i[thumbnail index_header index]
     config.view.gallery.partials = %i[index_header index]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -39,6 +39,10 @@ class SolrDocument
     to_openseadragon(blacklight_config.view_config(:show)).present?
   end
 
+  def intermediate_representation
+    JSON.parse(fetch('__raw_resource_json_ss'))
+  end
+
   private
 
   def shown_by_service(conforms_to:)

--- a/app/views/catalog/_ir_view.html.erb
+++ b/app/views/catalog/_ir_view.html.erb
@@ -1,0 +1,33 @@
+<% if can? :debug, Spotlight::Exhibit %>
+  <div class="accordion w-100">
+    <div class="card">
+      <div class="card-header" id="headingIr">
+        <h2 class="mb-0">
+          <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseIr" aria-expanded="false" aria-controls="collapseOne">
+            Intermediate Representation
+          </button>
+        </h2>
+      </div>
+
+      <div id="collapseIr" class="collapse" aria-labelledby="headingIr">
+        <div class="card-body">
+          <%= debug document.intermediate_representation %>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header" id="headingSolr">
+        <h2 class="mb-0">
+          <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseSolr" aria-expanded="false" aria-controls="collapseSolr">
+            Solr Document
+          </button>
+        </h2>
+      </div>
+      <div id="collapseSolr" class="collapse" aria-labelledby="headingSolr">
+        <div class="card-body" style="width: 800px;">
+          <%= debug document.to_h %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
## Why was this change made?
<img width="477" alt="Screen Shot 2019-11-08 at 13 06 13" src="https://user-images.githubusercontent.com/111218/68510502-929e0b80-0228-11ea-9a0d-07586dc22311.png">

## Was the documentation (README, API, wiki, ...) updated?
