### PR TITLE
Add a Statistics MainNavigation item and page for exhibits.

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+##
+# A controller for the public facing statistics page for the DLME Exhibit
+class StatisticsController < Spotlight::ApplicationController
+  before_action :attach_breadcrumbs
+  before_action do
+    authorize!(:read, current_exhibit)
+  end
+
+  def show; end
+
+  private
+
+  def attach_breadcrumbs
+    nav = current_exhibit.main_navigations.find_by(nav_type: 'statistics')
+    add_breadcrumb(
+      t(:'spotlight.curation.nav.home', title: current_exhibit.title),
+      spotlight.exhibit_home_page_path(current_exhibit)
+    )
+    add_breadcrumb(nav.label_or_default, exhibit_statistics_path(current_exhibit))
+  end
+end

--- a/app/views/shared/_statistics_navbar.html.erb
+++ b/app/views/shared/_statistics_navbar.html.erb
@@ -1,0 +1,5 @@
+<% if navigation.display? %>
+  <li class="nav-item <%= 'active' if controller_name == 'statistics' %>">
+    <%= link_to(navigation.label_or_default, exhibit_statistics_path(current_exhibit), class: 'nav-link') %>
+  </li>
+<% end %>

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="page-title"><%= t('statistics.header') %></h1>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -10,7 +10,7 @@ require 'open-uri'
 # Spotlight::Engine.config.default_blacklight_config = nil
 
 # ==> Appearance configuration
-# Spotlight::Engine.config.exhibit_main_navigation = [:curated_features, :browse, :about]
+Spotlight::Engine.config.exhibit_main_navigation = [:curated_features, :browse, :about, :statistics]
 # Spotlight::Engine.config.resource_partials = [
 #   'spotlight/resources/external_resources_form',
 #   'spotlight/resources/upload/form',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,12 +29,16 @@ en:
       sidebar:
         sources: 'Sources'
         transform: 'Transform data'
+    main_navigation:
+      statistics: Statistics
     search:
       fields:
         cho_title_ssim: Title
     resources:
       fetch:
           queued: 'Queued for processing.'
+  statistics:
+    header: Statistics
   transforms:
     notification:
       sent: 'Transform request sent.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :dlme_jsons if Settings.feature_flags.allow_json_upload
     resource :s3_harvester, controller: :"s3_harvester", only: [:create]
     resource :s3_delete, controller: :s3_delete, only: [:new, :create]
+    resource :statistics, only: :show
   end
 
   resource :transform, only: [:show, :create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Add a Statistics MainNavigation item for every exhibit that does not have one
+Spotlight::Exhibit.find_each do |exhibit|
+  nav = Spotlight::MainNavigation.find_or_initialize_by(exhibit_id: exhibit.id, nav_type: 'statistics')
+  if nav.new_record?
+    nav.display = false
+    nav.save
+  end
+end

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Statistics page', type: :feature do
+  before { create(:exhibit) }
+
+  it 'has a page available to users via a menu item in the exhibit navbar' do
+    visit root_path
+
+    within '.exhibit-navbar' do
+      click_link 'Statistics'
+    end
+
+    expect(page).to have_css('.exhibit-navbar li.nav-item.active', text: 'Statistics')
+    expect(page).to have_css('h1', text: 'Statistics')
+  end
+end


### PR DESCRIPTION
## Why was this change made?
<img width="678" alt="Because this" src="https://user-images.githubusercontent.com/96776/68518510-0fd57a80-0241-11ea-8825-634ec46ab6d9.png">

## Was the documentation (README, API, wiki, ...) updated?
n/a
