### PR TITLE
Update Bootstrap css overrides

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -85,44 +85,6 @@ body {
   }
 }
 
-// Ajustments to sidebars, more compact vertical spacing
-#sidebar li {
-  margin-top: 0;
-}
-
-#sidebar h4 {
-  border-bottom: 1px solid $color-gray-medium;
-  font-weight: 300;
-  font-size: 20px;
-  letter-spacing: 1px;
-  margin-bottom: 6px;
-  padding-bottom: 3px;
-  padding-left: 3px;
-
-  &.nav-heading {
-    margin-bottom: 6px;
-    padding-left: 3px;
-    padding-top: 0;
-  }
-}
-
-#sidebar ul.nav > li a {
-  padding: 3px 12px 6px 3px;
-
-  .blacklight-about_pages-show & {
-    padding-bottom: 4px;
-    padding-top: 4px;
-  }
-}
-
-#sidebar ol.sidenav > li > h4 {
-  border-bottom: 0;
-}
-
-#sidebar .top-panel-heading {
-  padding: 6px 0;
-}
-
 .masthead .site-title {
   white-space: normal;
 }

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -83,18 +83,18 @@ body {
   white-space: normal;
 }
 
-.facet_limit-active {
-  border-color: $color-gray-medium;
-}
+.facet-limit-active {
+  border-color: $color-gray-medium !important;
 
-.facet_limit-active > .panel-heading {
-  background-color: $color-gray-medium;
-  border-color: $color-black-light;
-  color: $color-blackish;
-}
+  & > .card-header {
+    background-color: $color-gray-medium !important;
+    border-color: $color-black-light;
+    color: $color-blackish;
+  }
 
-.facet_limit-active > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: $color-gray-medium;
+  & > .card-header + .panel-collapse > .card-body {
+    border-top-color: $color-gray-medium;
+  }
 }
 
 // Overrides for mobile viewports

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -72,17 +72,11 @@ body {
 }
 
 .breadcrumb {
-  background-color: transparent;
   border-bottom: 1px solid $color-gray-medium;
   padding-left: 0;
-
-  > .active {
-    color: $color-black-medium;
-  }
-
-  > li + li:before {
-    color: $color-black-light;
-  }
+  padding-right: 0;
+  margin-left: $breadcrumb-padding-x;
+  margin-right: $breadcrumb-padding-x;
 }
 
 .masthead .site-title {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -18,4 +18,9 @@ $pagination-active-color: $color-blackish;
 $pagination-active-bg: $color-gray-medium;
 $pagination-active-border: $color-gray-medium;
 
-$body-bg: $color-gray-lightest
+$body-bg: $color-gray-lightest;
+
+$breadcrumb-bg: transparent;
+$breadcrumb-active-color: $color-black-medium;
+$breadcrumb-divider-color: $color-black-light;
+$breadcrumb-padding-x: 0.5rem;


### PR DESCRIPTION
### Breadcrumb alignment
<img width="111" alt="Screen Shot 2019-11-11 at 08 02 13" src="https://user-images.githubusercontent.com/111218/68601652-982e6800-0459-11ea-99df-b95c6e1eff0d.png">

### Remove sidebar style overrides now that a more compact sidebar is upstream

<img width="294" alt="Screen Shot 2019-11-11 at 07 53 17" src="https://user-images.githubusercontent.com/111218/68601012-581ab580-0458-11ea-8958-b5a9e61b84ae.png">

### Active facet
<img width="331" alt="Screen Shot 2019-11-11 at 08 07 06" src="https://user-images.githubusercontent.com/111218/68601957-476b3f00-045a-11ea-8b37-851af9f7c5c7.png">
