### PR TITLE
Add javascript assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ end
 gem 'aws-sdk-sns'
 
 gem 'blacklight-spotlight', github: 'projectblacklight/spotlight'
+gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 
 gem 'friendly_id'
 gem 'iiif-presentation', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,6 +539,10 @@ GEM
     turbolinks-source (5.2.0)
     twitter-text (1.14.7)
       unf (~> 0.1.0)
+    twitter-typeahead-rails (0.11.1.pre.corejavascript)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -619,6 +623,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
+  twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webdrivers

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,9 @@
 // Required by Blacklight
 //= require jquery3
 //= require bootstrap
+//= require bootstrap/util
+//= require popper
+//= require twitter/typeahead
 //= require blacklight/blacklight
 
 //= require transform_result


### PR DESCRIPTION
## Why was this change made?

The typehead and popper.js dependencies are injected by the blacklight 7 asset generator.

## Was the documentation (README, API, wiki, ...) updated?
