### PR TITLE
Add the items section to the Statistics dashboard

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -110,6 +110,8 @@ class CatalogController < ApplicationController
     arabic_locale = ->(*_) { I18n.locale == :ar }
     en_locale = ->(*_) { I18n.locale == :en }
 
+    config.add_facet_field 'type_pivot_en', pivot: %w[cho_edm_type.en_ssim cho_has_type.en_ssim], if: false
+    config.add_facet_field 'type_pivot_ar', pivot: %w[cho_edm_type.ar-Arab_ssim cho_has_type.ar-Arab_ssim], if: false
     config.add_facet_field 'language_ar',    field: 'cho_language.ar-Arab_ssim', limit: true, if: arabic_locale
     config.add_facet_field 'language_en',    field: 'cho_language.en_ssim', limit: true, if: en_locale
     config.add_facet_field 'type_ar',    field: 'cho_edm_type.ar-Arab_ssim', limit: true, if: arabic_locale

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -3,12 +3,16 @@
 ##
 # A controller for the public facing statistics page for the DLME Exhibit
 class StatisticsController < Spotlight::ApplicationController
+  include Blacklight::Searchable
+
   before_action :attach_breadcrumbs
   before_action do
     authorize!(:read, current_exhibit)
   end
 
-  def show; end
+  def show
+    @statistics_dashboard = StatisticsDashboard.new(search_service: search_service)
+  end
 
   private
 

--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+##
+# A class to model the statistics on the exhibit statistics dashboard.
+# This Dashboard class requires that a Blacklight SearchServices is injected into it
+class StatisticsDashboard
+  attr_reader :search_service
+  def initialize(search_service:)
+    @search_service = search_service
+  end
+
+  def items
+    @items ||= Items.new(search_service)
+  end
+
+  # Represents data in the Itms section of the dashboard
+  class Items
+    LOCALE_MAP = { 'ar' => 'ar-Arab' }.with_indifferent_access
+
+    attr_reader :search_service
+    def initialize(search_service)
+      @search_service = search_service
+    end
+
+    def total
+      response.dig('response', 'numFound')
+    end
+
+    def to_partial_path
+      'statistics/items'
+    end
+
+    def language_field
+      "cho_language.#{mapped_locale}_ssim"
+    end
+
+    def by_language
+      (facet_fields[language_field] || []).each_slice(2).collect do |(value, count)|
+        { 'value' => value, 'count' => count }
+      end
+    end
+
+    def type_field
+      "cho_edm_type.#{mapped_locale}_ssim"
+    end
+
+    def sub_type_field
+      "cho_has_type.#{mapped_locale}_ssim"
+    end
+
+    def by_type
+      pivot_facets["#{type_field},#{sub_type_field}"] || []
+    end
+
+    private
+
+    def mapped_locale
+      LOCALE_MAP[I18n.locale] || I18n.locale
+    end
+
+    def facet_fields
+      facets['facet_fields'] || {}
+    end
+
+    def pivot_facets
+      facets['facet_pivot'] || {}
+    end
+
+    def facets
+      response.dig('facet_counts') || {}
+    end
+
+    def response
+      @response ||= search_service.search_results&.first || {}
+    end
+  end
+end

--- a/app/views/statistics/_items.html.erb
+++ b/app/views/statistics/_items.html.erb
@@ -1,0 +1,57 @@
+<h2><%= t('statistics.dashboard.items.total_html', total: items.total) %></h2>
+<div class="row">
+  <div class="col-6">
+    <table class="table table-striped by-type">
+      <thead>
+        <tr>
+          <th><%= t('statistics.dashboard.items.by_type') %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% items.by_type.each do |field| %>
+          <tr>
+            <td>
+              <%= link_to path_for_facet(items.type_field, field['value']) do %>
+                <%= facet_display_value(items.type_field, field['value']) %>
+              <% end %>
+            </td>
+            <td class="text-right"><%= field['count'] %></td>
+          </tr>
+          <% field['pivot'].each do |pivot| %>
+            <tr>
+              <td class="pl-5">
+                <%= link_to "#{path_for_facet(items.sub_type_field, pivot['value'])}&#{{ f: { items.type_field => [field['value']] } }.to_query}" do %>
+                  <%= facet_display_value(items.sub_type_field, pivot['value']) %>
+                <% end %>
+              </td>
+              <td class="text-right"><%= pivot['count'] %></td>
+            </tr>
+          <% end if field['pivot'] %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="col-6">
+    <table class="table table-striped by-language">
+      <thead>
+        <tr>
+          <th><%= t('statistics.dashboard.items.by_language') %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% items.by_language.each do |field| %>
+          <tr>
+            <td>
+              <%= link_to path_for_facet(items.language_field, field['value']) do %>
+                <%= facet_display_value(items.language_field, field['value']) %>
+              <% end %>
+            </td>
+            <td class="text-right"><%= field['count'] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -1,1 +1,17 @@
 <h1 class="page-title"><%= t('statistics.header') %></h1>
+
+<div class="row d-none d-md-flex justify-content-around">
+  <div class="jumbotron col-4-md">
+    <h2 class="display-6">
+      <%= t('statistics.dashboard.header.total_items', count: @statistics_dashboard.items.total) %>
+    </h2>
+    <hr class="my-4">
+    <p class="text-center">
+      <%= t('statistics.dashboard.header.total_types', count: @statistics_dashboard.items.by_type.count) %>
+    </p>
+  </div>
+</div>
+
+<hr />
+
+<%= render @statistics_dashboard.items %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,18 @@ en:
       fetch:
           queued: 'Queued for processing.'
   statistics:
+    dashboard:
+      header:
+        total_items:
+          one: 1 item
+          other: '%{count} items'
+        total_types:
+          one: 1 item type
+          other: '%{count} item types'
+      items:
+        by_language: By language
+        by_type: By type
+        total_html: Items &middot; %{total}
     header: Statistics
   transforms:
     notification:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :exhibits, only: [] do
+  resources :exhibits, only: [], path: '/' do
     resources :dlme_jsons if Settings.feature_flags.allow_json_upload
     resource :s3_harvester, controller: :"s3_harvester", only: [:create]
     resource :s3_delete, controller: :s3_delete, only: [:new, :create]

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -3,7 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe 'Statistics page', type: :feature do
-  before { create(:exhibit) }
+  let(:stub_response) do
+    { 'response' => { 'numFound' => 100 } }
+  end
+  let(:stub_dashboard) do
+    StatisticsDashboard.new(search_service: instance_double(
+      'SearchService',
+      search_results: [stub_response]
+    ))
+  end
+
+  before do
+    create(:exhibit)
+    allow(StatisticsDashboard).to receive(:new).and_return(stub_dashboard)
+  end
 
   it 'has a page available to users via a menu item in the exhibit navbar' do
     visit root_path
@@ -14,5 +27,15 @@ RSpec.describe 'Statistics page', type: :feature do
 
     expect(page).to have_css('.exhibit-navbar li.nav-item.active', text: 'Statistics')
     expect(page).to have_css('h1', text: 'Statistics')
+  end
+
+  it 'has an items section' do
+    visit root_path
+
+    within '.exhibit-navbar' do
+      click_link 'Statistics'
+    end
+
+    expect(page).to have_css('h2', text: 'Items · 100')
   end
 end

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatisticsDashboard do
+  subject(:dashboard) do
+    described_class.new(
+      search_service: instance_double(
+        'SearchService',
+        search_results: [stub_response]
+      )
+    )
+  end
+
+  let(:stub_response) do
+    { 'response' => { 'numFound' => 100 } }
+  end
+
+  it 'has items' do
+    expect(dashboard.items).to be_a StatisticsDashboard::Items
+  end
+
+  describe 'Items' do
+    let(:items) { dashboard.items }
+
+    it 'has the total from the response' do
+      expect(items.total).to be 100
+    end
+
+    describe '#by_language' do
+      let(:stub_response) do
+        { 'facet_counts' => { 'facet_fields' => {
+          'cho_language.en_ssim' => ['Value 1', '500', 'Value 2', '300']
+        } } }
+      end
+
+      it 'is transforms the facet array into an array of value/count hashes' do
+        expect(items.by_language.length).to eq 2
+        expect(items.by_language).to include('value' => 'Value 1', 'count' => '500')
+        expect(items.by_language).to include('value' => 'Value 2', 'count' => '300')
+      end
+    end
+
+    describe '#by_type' do
+      let(:stub_response) do
+        { 'facet_counts' => { 'facet_pivot' => {
+          'cho_edm_type.en_ssim,cho_has_type.en_ssim' => [
+            { 'value' => 'Value 1', 'count' => '500', 'pivot' => {} },
+            { 'value' => 'Value 2', 'count' => '300', 'pivot' => {} }
+          ]
+        } } }
+      end
+
+      it 'pulls the type/sub type pivot facet from the response' do
+        expect(items.by_type.length).to eq 2
+        expect(items.by_type).to include('value' => 'Value 1', 'count' => '500', 'pivot' => {})
+        expect(items.by_type).to include('value' => 'Value 2', 'count' => '300', 'pivot' => {})
+      end
+    end
+
+    describe 'locale aware field names' do
+      it 'are available fo language and type fields (and maps to locale codes to bcp47 codes)' do
+        expect(items.language_field).to eq 'cho_language.en_ssim'
+        expect(items.type_field).to eq 'cho_edm_type.en_ssim'
+        expect(items.sub_type_field).to eq 'cho_has_type.en_ssim'
+
+        allow(I18n).to receive(:locale).and_return('ar')
+
+        expect(items.language_field).to eq 'cho_language.ar-Arab_ssim'
+        expect(items.type_field).to eq 'cho_edm_type.ar-Arab_ssim'
+        expect(items.sub_type_field).to eq 'cho_has_type.ar-Arab_ssim'
+      end
+    end
+  end
+end

--- a/spec/views/statistics/_items.html.erb_spec.rb
+++ b/spec/views/statistics/_items.html.erb_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'statistics/_items.html.erb', type: :view do
+  before do
+    controller.singleton_class.class_eval do
+      include Blacklight::Controller
+    end
+
+    render partial: 'statistics/items', locals: {
+      items: items
+    }
+  end
+
+  let(:stub_response) do
+    { 'facet_counts' => {
+      'facet_fields' => {
+        'cho_language.en_ssim' => ['Value 1', '500', 'Value 2', '300']
+      },
+      'facet_pivot' => {
+        'cho_edm_type.en_ssim,cho_has_type.en_ssim' => [
+          { 'value' => 'Value 1', 'count' => '500' },
+          { 'value' => 'Value 2', 'count' => '300', 'pivot' => [
+            { 'value' => 'Value A', 'count' => '200' },
+            { 'value' => 'Value B', 'count' => '100' }
+          ] }
+        ]
+      }
+    } }
+  end
+
+  let(:items) do
+    StatisticsDashboard::Items.new(
+      instance_double(
+        'SearchService',
+        search_results: [stub_response]
+      )
+    )
+  end
+
+  describe 'By type section' do
+    it 'has a table with linked langage values and their counts' do
+      expect(rendered).to have_css('table.by-type')
+      expect(rendered).to have_css('table.by-type tr a', text: 'Value 1')
+      expect(rendered).to have_css('table.by-type tr a', text: 'Value 2')
+      expect(rendered).to have_css('table.by-type tr td', text: '500')
+      expect(rendered).to have_css('table.by-type tr td', text: '300')
+    end
+
+    it 'includes a first level of pivot facets (indented)' do
+      expect(rendered).to have_css('table.by-type tr td.pl-5 a', text: 'Value A')
+      expect(rendered).to have_css('table.by-type tr td.pl-5 a', text: 'Value B')
+      expect(rendered).to have_css('table.by-type tr td', text: '200')
+      expect(rendered).to have_css('table.by-type tr td', text: '100')
+    end
+  end
+
+  describe 'By language section' do
+    it 'has a table with linked language values and their counts' do
+      expect(rendered).to have_css('table.by-language')
+      expect(rendered).to have_css('table.by-language tr a', text: 'Value 1')
+      expect(rendered).to have_css('table.by-language tr a', text: 'Value 2')
+      expect(rendered).to have_css('table.by-language tr td', text: '500')
+      expect(rendered).to have_css('table.by-language tr td', text: '300')
+    end
+  end
+end


### PR DESCRIPTION
Part of #531 

## Why was this change made?
To add item details to the statistics page.


## Was the documentation (README, API, wiki, ...) updated?


<img width="883" alt="Screen Shot 2019-11-14 at 3 52 05 PM" src="https://user-images.githubusercontent.com/96776/68905641-bebcff00-06f6-11ea-9568-d3e9e1cc336f.png">
<img width="896" alt="Screen Shot 2019-11-14 at 3 51 30 PM" src="https://user-images.githubusercontent.com/96776/68905642-bf559580-06f6-11ea-979e-112855d95999.png">



## TODO
- [x] i18n the strings (holding off to avoid churn/understand doc structure)
- [x] Decide if we want to add a class to represent statistics / migrate `@response` accessors out of view.
- [x] Fix-up pivot facet access/linking (it's pretty sloppy/brittle right now)