### PR TITLE
Add translations menu from upstream

### DIFF
--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -16,4 +16,7 @@
   <% if can? :manage, Spotlight::AboutPage.new(exhibit: current_exhibit) %>
   <li class="nav-item"><%= link_to t(:'spotlight.curation.sidebar.about_pages'), spotlight.exhibit_about_pages_path(current_exhibit), class: 'nav-link', 'data-no-turbolink' => true %></li>
   <% end %>
+  <% if (can? :manage, current_exhibit.translations.first_or_initialize) && current_exhibit.languages.any? %>
+    <%= nav_link t(:'spotlight.curation.sidebar.translations'), spotlight.edit_exhibit_translations_path(current_exhibit), 'data-no-turbolink' => true %>
+  <% end %>
 </ul>


### PR DESCRIPTION
## Why was this change made?
This enables access to the Curation > Translations menu. This is necessary for translating about pages, browse categories, and some navigation elements.

## Was the documentation (README, API, wiki, ...) updated?
