### PR TITLE
Reorder the javascript to put popper above bootstrap

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,12 +13,13 @@
 //= require rails-ujs
 //= require turbolinks
 //
+//
 // Required by Blacklight
 //= require jquery3
-//= require bootstrap
-//= require bootstrap/util
 //= require popper
 //= require twitter/typeahead
+//= require bootstrap
+//= require bootstrap/util
 //= require blacklight/blacklight
 
 //= require transform_result


### PR DESCRIPTION
This was how it was originally generated, and apparently worked fine at the time 🤷‍♂ 

## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
