### PR TITLE
Enable i18n fallbacks in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,10 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = false
+
+  # Uses default locale instead of displaying 'translation missing' error
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
## Why was this change made?
To remove noise for troubleshooting RTL UI. @ggeisler, if this is useful for your local dev environment, please feel free to merge while we're away.

### Before
<img width="1172" alt="translation missing errors" src="https://user-images.githubusercontent.com/5402927/68725521-89d46f00-0573-11ea-9acb-0fd23709f44d.png">

### After
<img width="1150" alt="fallback configured" src="https://user-images.githubusercontent.com/5402927/68725519-89d46f00-0573-11ea-81a6-985b3857c8aa.png">

## Was the documentation (README, API, wiki, ...) updated?
