### PR TITLE
Add a hierarchical facet (and show field) for the cho_type_facet field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'riiif', '~> 2.0'
 gem 'sitemap_generator'
 
 gem 'blacklight-gallery', '>= 0.3.0'
+gem 'blacklight-hierarchy', github: 'sul-dlss/blacklight-hierarchy'
 gem 'blacklight-oembed', '>= 0.1.0'
 gem 'jquery-rails'
 gem 'rails_autolink'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/projectblacklight/spotlight.git
+  remote: https://github.com/projectblacklight/spotlight.git
   revision: 2fdace3d7d043eeea6e13a16af34299e1c7a3dad
   specs:
     blacklight-spotlight (3.0.0.alpha)
@@ -38,6 +38,15 @@ GIT
       sprockets-es6
       tophat
       underscore-rails (~> 1.6)
+
+GIT
+  remote: https://github.com/sul-dlss/blacklight-hierarchy.git
+  revision: 8fd4a13209fcaa8ad13df2808edb0e7fcb873f94
+  specs:
+    blacklight-hierarchy (3.0.0.alpha)
+      blacklight (~> 7.0)
+      jquery-rails
+      rails (>= 4.1, < 6)
 
 GEM
   remote: https://rubygems.org/
@@ -576,6 +585,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-sns
   blacklight-gallery (>= 0.3.0)
+  blacklight-hierarchy!
   blacklight-oembed (>= 0.1.0)
   blacklight-spotlight!
   bootsnap (>= 1.1.0)

--- a/app/assets/javascripts/blacklight_hierarchy.js
+++ b/app/assets/javascripts/blacklight_hierarchy.js
@@ -1,0 +1,1 @@
+//= require blacklight/hierarchy/hierarchy

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,8 +3,10 @@
 @import 'bootstrap';
 @import 'blacklight';
 @import 'blacklight_gallery';
+@import 'blacklight_hierarchy';
 @import 'spotlight';
 @import 'openseadragon';
 @import 'footer';
 @import 'dlme';
+@import 'facets';
 @import 'rtl';

--- a/app/assets/stylesheets/blacklight_hierarchy.scss
+++ b/app/assets/stylesheets/blacklight_hierarchy.scss
@@ -1,0 +1,3 @@
+/*
+ *= require blacklight/hierarchy/hierarchy
+ */

--- a/app/assets/stylesheets/facets.scss
+++ b/app/assets/stylesheets/facets.scss
@@ -1,0 +1,50 @@
+// Add some styling around hierarchical facets
+ul.facet-hierarchy {
+  &,
+  ul {
+    padding-left: 0;
+  }
+
+  .facet-count {
+    display: inline-block;
+    float: right;
+    text-align: right;
+    width: 4.5em;
+  }
+
+  .facet_select {
+    display: inline-block;
+    margin-bottom: 6px;
+    max-width: calc(100% - 5em);
+  }
+
+  .h-node {
+    cursor: pointer;
+    list-style-image: none;
+    list-style-type: none;
+    padding-left: 15px;
+
+    &.twiddle {
+      &:before {
+        content: '⊞';
+        display: inline-block;
+        margin-left: -15px;
+        vertical-align: top;
+        width: 15px;
+      }
+    }
+
+    &.twiddle-open {
+      list-style-image: none;
+      list-style-type: none;
+
+      &:before {
+        content: '⊟';
+      }
+    }
+  }
+
+  .h-leaf {
+    margin-left: 15px;
+  }
+}

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -73,4 +73,17 @@ $breadcrumb-item-padding-x: 0.5rem !default;
   .view-type-list {
       transform: scale(-1);
   }
+
+  // Fix spacing on facet icons/counts
+  ul.facet-hierarchy {
+    .facet-count {
+      float: left;
+      text-align: left;
+    }
+
+    .twiddle:before {
+      margin-left: 0;
+      margin-right: -15px;
+    }
+  }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -189,6 +189,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'same_as', field: 'cho_same_as_ssim', autolink: true
     config.add_show_field 'subject', field: 'cho_subject_ssim'
     config.add_show_field 'type', field: 'cho_type_ssim'
+    config.add_show_field 'type_en', field: 'cho_type_facet.en_ssim', helper_method: :link_type_hierarchy, if: en_locale
+    config.add_show_field 'type_ar', field: 'cho_type_facet.ar-Arab_ssim', helper_method: :link_type_hierarchy, if: arabic_locale
 
     config.add_show_field '__source', field: '__source_ssim'
     config.add_show_field 'agg_dc_rights', field: 'agg_dc_rights_ssim'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -126,6 +126,20 @@ class CatalogController < ApplicationController
     config.add_facet_field 'agg_data_provider_en',    field: 'agg_data_provider.en_ssim', limit: true, if: en_locale
     config.add_facet_field 'agg_provider_ar',    field: 'agg_provider.ar-Arab_ssim', limit: true, if: arabic_locale
     config.add_facet_field 'agg_provider_en',    field: 'agg_provider.en_ssim', limit: true, if: en_locale
+    config.add_facet_field 'cho_type_facet.en_ssim',
+                           partial: 'blacklight/hierarchy/facet_hierarchy',
+                           label: 'Type en',
+                           if: en_locale
+    config.add_facet_field 'cho_type_facet.ar-Arab_ssim',
+                           partial: 'blacklight/hierarchy/facet_hierarchy',
+                           label: 'Type ar',
+                           if: arabic_locale
+    config.facet_display = {
+      hierarchy: {
+        'cho_type_facet.en' => [['ssim'], ':'],
+        'cho_type_facet.ar-Arab' => [['ssim'], ':']
+      }
+    }
 
     config.add_facet_field 'thumbnail', query: {
       yes: { label: 'Yes', fq: 'agg_preview.wr_id_ssim:[* TO *]' },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def link_type_hierarchy(args)
+    # we only want the last one because it will be the deepest leaf of the hierarchy
+    values = args[:values]&.last&.split(':')
+    return unless values
+
+    safe_join(
+      values.each_with_index.collect do |value, index|
+        facet_value = values[0, index + 1].join(':')
+        link_to(value, path_for_facet(args[:field], facet_value))
+      end,
+      ' › '
+    )
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  before do
+    controller.singleton_class.class_eval do
+      include Blacklight::Controller
+    end
+  end
+
+  describe '#link_type_hierarchy' do
+    it 'is nil when the data needed to build the hierarchy is not present' do
+      expect(helper.link_type_hierarchy({})).to be_nil
+      expect(helper.link_type_hierarchy(values: [])).to be_nil
+    end
+
+    it 'links a single value' do
+      expect(
+        helper.link_type_hierarchy(values: ['Sound'], field: 'cho_type_facet')
+      ).to have_link('Sound', href: /\?f%5Bcho_type_facet%5D%5B%5D=Sound&/)
+    end
+
+    it 'links multiple values (with each value including all preceeding values)' do
+      links = helper.link_type_hierarchy(values: ['Sound:Interview'], field: 'cho_type_facet')
+
+      expect(links).to have_content('Sound › Interview')
+      expect(links).to have_link('Sound', href: /\?f%5Bcho_type_facet%5D%5B%5D=Sound&/)
+      expect(links).to have_link('Interview', href: /\?f%5Bcho_type_facet%5D%5B%5D=Sound%3AInterview&/)
+    end
+  end
+end


### PR DESCRIPTION
Closes #552 

## Why was this change made?
To add support for a type/sub-type hierarchical facet.

## Was the documentation (README, API, wiki, ...) updated?
n/a

<img width="292" alt="facet" src="https://user-images.githubusercontent.com/96776/68981273-bed10380-07b7-11ea-9486-204911525423.png">
<img width="596" alt="show-view" src="https://user-images.githubusercontent.com/96776/68981274-bed10380-07b7-11ea-8a4a-0b080ce015ec.png">

