### PR TITLE
Fix RTL styling for hierarchical facets

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -86,4 +86,20 @@ $breadcrumb-item-padding-x: 0.5rem !default;
       margin-right: -15px;
     }
   }
+
+  // blacklight-hierarchy overrides
+
+  ul.facet-hierarchy {
+    padding-right: 0;
+
+    .h-node {
+      padding-left: 0;
+      padding-right: 15px;
+    }
+
+    .h-leaf {
+      margin-left: 0;
+      margin-right: 15px;
+    }
+  }
 }


### PR DESCRIPTION
Part of #676 

Before:
<img width="345" alt="Screen Shot 2019-11-18 at 11 41 40" src="https://user-images.githubusercontent.com/111218/69084127-6e94b400-09f8-11ea-96e3-1a8ac888d395.png">

After:
![Screen Shot 2019-11-18 at 11 40 08](https://user-images.githubusercontent.com/111218/69084079-515fe580-09f8-11ea-94e6-14eb2f198f10.png)
