### PR TITLE
Move FixSnsJsonMiddleware to production/test so it doesn't…

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,5 @@ module Dlme
     # -- all .rb files in that directory are automatically loaded.
 
     config.middleware.use Rack::Attack
-    config.middleware.insert_after(Rack::Attack, FixSnsJsonMiddleware)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,4 +93,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.lograge.enabled = true
+
+  config.middleware.insert_after(Rack::Attack, FixSnsJsonMiddleware)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.slowpoke.timeout = 60
+
+  config.middleware.insert_after(Rack::Attack, FixSnsJsonMiddleware)
 end


### PR DESCRIPTION
…run in development.

## Why was this change made?
I've seen this milddleware swallow up errors (e.g. an error occurs in development, and our stacktrace comes from here instead of the true root of the issue).  I've found myself commenting this out in development from time to time.

## Was the documentation (README, API, wiki, ...) updated?
