### PR TITLE
Update the by type link on the status dashboard to use the new …

### DIFF
--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -40,12 +40,8 @@ class StatisticsDashboard
       end
     end
 
-    def type_field
-      "cho_edm_type.#{mapped_locale}_ssim"
-    end
-
-    def sub_type_field
-      "cho_has_type.#{mapped_locale}_ssim"
+    def type_facet
+      "cho_type_facet.#{mapped_locale}_ssim"
     end
 
     def by_type
@@ -53,6 +49,14 @@ class StatisticsDashboard
     end
 
     private
+
+    def type_field
+      "cho_edm_type.#{mapped_locale}_ssim"
+    end
+
+    def sub_type_field
+      "cho_has_type.#{mapped_locale}_ssim"
+    end
 
     def mapped_locale
       LOCALE_MAP[I18n.locale] || I18n.locale

--- a/app/views/statistics/_items.html.erb
+++ b/app/views/statistics/_items.html.erb
@@ -12,8 +12,8 @@
         <% items.by_type.each do |field| %>
           <tr>
             <td>
-              <%= link_to path_for_facet(items.type_field, field['value']) do %>
-                <%= facet_display_value(items.type_field, field['value']) %>
+              <%= link_to path_for_facet(items.type_facet, field['value']) do %>
+                <%= facet_display_value(items.type_facet, field['value']) %>
               <% end %>
             </td>
             <td class="text-right"><%= field['count'] %></td>
@@ -21,8 +21,8 @@
           <% field['pivot'].each do |pivot| %>
             <tr>
               <td class="pl-5">
-                <%= link_to "#{path_for_facet(items.sub_type_field, pivot['value'])}&#{{ f: { items.type_field => [field['value']] } }.to_query}" do %>
-                  <%= facet_display_value(items.sub_type_field, pivot['value']) %>
+                <%= link_to path_for_facet(items.type_facet, [field['value'], pivot['value']].join(':')) do %>
+                  <%= facet_display_value(items.type_facet, pivot['value']) %>
                 <% end %>
               </td>
               <td class="text-right"><%= pivot['count'] %></td>

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -61,14 +61,12 @@ RSpec.describe StatisticsDashboard do
     describe 'locale aware field names' do
       it 'are available fo language and type fields (and maps to locale codes to bcp47 codes)' do
         expect(items.language_field).to eq 'cho_language.en_ssim'
-        expect(items.type_field).to eq 'cho_edm_type.en_ssim'
-        expect(items.sub_type_field).to eq 'cho_has_type.en_ssim'
+        expect(items.type_facet).to eq 'cho_type_facet.en_ssim'
 
         allow(I18n).to receive(:locale).and_return('ar')
 
         expect(items.language_field).to eq 'cho_language.ar-Arab_ssim'
-        expect(items.type_field).to eq 'cho_edm_type.ar-Arab_ssim'
-        expect(items.sub_type_field).to eq 'cho_has_type.ar-Arab_ssim'
+        expect(items.type_facet).to eq 'cho_type_facet.ar-Arab_ssim'
       end
     end
   end


### PR DESCRIPTION
…hierarchical facet.

## Why was this change made?
I'm assuming that we want the dashboard display to link to the hierarchical facet.

Note, this is still using the individual facets as a transitional pivot facet to render the display. 

## Was the documentation (README, API, wiki, ...) updated?
