### PR TITLE
Style metadata + facet values with bidi logic

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -1,6 +1,18 @@
 $breadcrumb-item-padding-x: 0.5rem !default;
 @import 'bootstrap/rtl';
 
+.facet-label {
+  unicode-bidi: plaintext;
+}
+
+.index_title a {
+  unicode-bidi: plaintext;
+}
+
+.document-metadata {
+  dd { unicode-bidi: plaintext; }
+}
+
 .rtl,
 [dir="rtl"] {
   /** The upstream stylsheet doesn't expect dir="rtl" on the <html> element.. */

--- a/app/processors/bidi_wrap.rb
+++ b/app/processors/bidi_wrap.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Wrap document values in <bdi> so they can calculate their own LTR/RTL-ness
+# and not influence other page content
+class BidiWrap < Blacklight::Rendering::AbstractStep
+  include ActionView::Helpers::TagHelper
+
+  def render
+    next_step(values.map { |x| wrap(x) })
+  end
+
+  private
+
+  def wrap(val)
+    content_tag :bdi, val, class: 'metadata-value'
+  end
+end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -3,5 +3,6 @@ Blacklight::Rendering::Pipeline.operations = [Blacklight::Rendering::HelperMetho
                                               Blacklight::Rendering::LinkToFacet,
                                               Blacklight::Rendering::Microdata,
                                               Autolink,
+                                              BidiWrap,
                                               Paragraph,
                                               Join]

--- a/spec/processors/autolink_spec.rb
+++ b/spec/processors/autolink_spec.rb
@@ -60,17 +60,4 @@ RSpec.describe ::Autolink do
       end
     end
   end
-
-  describe 'Blacklight::Rendering::Pipeline#operations' do
-    subject(:operations) { Blacklight::Rendering::Pipeline.operations }
-
-    it {
-      expect(operations).to eq [Blacklight::Rendering::HelperMethod,
-                                Blacklight::Rendering::LinkToFacet,
-                                Blacklight::Rendering::Microdata,
-                                Autolink,
-                                Paragraph,
-                                Join]
-    }
-  end
 end


### PR DESCRIPTION
This should stop it from being w…rongly influenc-ed/-ing by other content

## Before
<img width="868" alt="Screen Shot 2019-11-18 at 16 11 30" src="https://user-images.githubusercontent.com/111218/69104732-2e482c80-0a1e-11ea-8edf-6293328a8b7a.png">

## After
<img width="917" alt="Screen Shot 2019-11-18 at 16 11 43" src="https://user-images.githubusercontent.com/111218/69104729-28eae200-0a1e-11ea-987a-b6ab801485e8.png">

