### PR TITLE
Add a Contributors section to the Statistics Dashboard

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,6 +119,14 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'type_pivot_en', pivot: %w[cho_edm_type.en_ssim cho_has_type.en_ssim], if: false
     config.add_facet_field 'type_pivot_ar', pivot: %w[cho_edm_type.ar-Arab_ssim cho_has_type.ar-Arab_ssim], if: false
+
+    config.add_facet_field 'contributor_pivot_en',
+                           pivot: %w[agg_provider.en_ssim agg_provider_country.en_ssim],
+                           if: false
+    config.add_facet_field 'contributor_pivot_ar',
+                           pivot: %w[agg_provider.ar-Arab_ssim agg_provider_country.ar-Arab_ssim],
+                           if: false
+
     config.add_facet_field 'language_ar',    field: 'cho_language.ar-Arab_ssim', limit: true, if: arabic_locale
     config.add_facet_field 'language_en',    field: 'cho_language.en_ssim', limit: true, if: en_locale
     config.add_facet_field 'type_ar',    field: 'cho_edm_type.ar-Arab_ssim', limit: true, if: arabic_locale
@@ -135,6 +143,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'agg_data_provider_en',    field: 'agg_data_provider.en_ssim', limit: true, if: en_locale
     config.add_facet_field 'agg_provider_ar',    field: 'agg_provider.ar-Arab_ssim', limit: true, if: arabic_locale
     config.add_facet_field 'agg_provider_en',    field: 'agg_provider.en_ssim', limit: true, if: en_locale
+    config.add_facet_field 'agg_provider_country_ar', field: 'agg_provider_country.ar-Arab_ssim', if: false
+    config.add_facet_field 'agg_provider_country_en', field: 'agg_provider_country.en_ssim', if: false
     config.add_facet_field 'cho_type_facet.en_ssim',
                            partial: 'blacklight/hierarchy/facet_hierarchy',
                            label: 'Type en',

--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -4,22 +4,28 @@
 # A class to model the statistics on the exhibit statistics dashboard.
 # This Dashboard class requires that a Blacklight SearchServices is injected into it
 class StatisticsDashboard
+  LOCALE_MAP = { 'ar' => 'ar-Arab' }.with_indifferent_access
+
   attr_reader :search_service
   def initialize(search_service:)
     @search_service = search_service
   end
 
   def items
-    @items ||= Items.new(search_service)
+    @items ||= Items.new(response)
+  end
+
+  private
+
+  def response
+    @response ||= search_service.search_results&.first || {}
   end
 
   # Represents data in the Itms section of the dashboard
   class Items
-    LOCALE_MAP = { 'ar' => 'ar-Arab' }.with_indifferent_access
-
-    attr_reader :search_service
-    def initialize(search_service)
-      @search_service = search_service
+    attr_reader :response
+    def initialize(response)
+      @response = response
     end
 
     def total
@@ -59,7 +65,7 @@ class StatisticsDashboard
     end
 
     def mapped_locale
-      LOCALE_MAP[I18n.locale] || I18n.locale
+      StatisticsDashboard::LOCALE_MAP[I18n.locale] || I18n.locale
     end
 
     def facet_fields
@@ -72,10 +78,6 @@ class StatisticsDashboard
 
     def facets
       response.dig('facet_counts') || {}
-    end
-
-    def response
-      @response ||= search_service.search_results&.first || {}
     end
   end
 end

--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -19,6 +19,18 @@ class StatisticsDashboard
     @contributors ||= Contributors.new(response)
   end
 
+  class << self
+    def locale_aware_field(field_name, suffix = 'ssim')
+      "#{field_name}.#{mapped_locale}_#{suffix}"
+    end
+
+    private
+
+    def mapped_locale
+      StatisticsDashboard::LOCALE_MAP[I18n.locale] || I18n.locale
+    end
+  end
+
   private
 
   def response
@@ -41,7 +53,7 @@ class StatisticsDashboard
     end
 
     def language_field
-      "cho_language.#{mapped_locale}_ssim"
+      StatisticsDashboard.locale_aware_field('cho_language')
     end
 
     def by_language
@@ -51,7 +63,7 @@ class StatisticsDashboard
     end
 
     def type_facet
-      "cho_type_facet.#{mapped_locale}_ssim"
+      StatisticsDashboard.locale_aware_field('cho_type_facet')
     end
 
     def by_type
@@ -61,15 +73,11 @@ class StatisticsDashboard
     private
 
     def type_field
-      "cho_edm_type.#{mapped_locale}_ssim"
+      StatisticsDashboard.locale_aware_field('cho_edm_type')
     end
 
     def sub_type_field
-      "cho_has_type.#{mapped_locale}_ssim"
-    end
-
-    def mapped_locale
-      StatisticsDashboard::LOCALE_MAP[I18n.locale] || I18n.locale
+      StatisticsDashboard.locale_aware_field('cho_has_type')
     end
 
     def facet_fields
@@ -107,7 +115,7 @@ class StatisticsDashboard
     end
 
     def provider_field
-      "agg_provider.#{mapped_locale}_ssim"
+      StatisticsDashboard.locale_aware_field('agg_provider')
     end
 
     # Represents each row in the Contributors table
@@ -133,11 +141,7 @@ class StatisticsDashboard
     private
 
     def countries_field
-      "agg_provider_country.#{mapped_locale}_ssim"
-    end
-
-    def mapped_locale
-      StatisticsDashboard::LOCALE_MAP[I18n.locale] || I18n.locale
+      StatisticsDashboard.locale_aware_field('agg_provider_country')
     end
 
     def pivot_facets

--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -1,0 +1,20 @@
+<h2><%= t('statistics.dashboard.contributors.total_html', total: contributors.total) %></h2>
+
+<table class="table table-striped contributors">
+  <thead>
+    <tr>
+      <th><%= t('statistics.dashboard.contributors.table.institution') %></th>
+      <th><%= t('statistics.dashboard.contributors.table.country') %></th>
+      <th><%= t('statistics.dashboard.contributors.table.items') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% contributors.institutions.each do |institution| %>
+      <tr>
+        <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name) %></td>
+        <td><%= institution.country %></td>
+        <td><%= institution.item_count %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -15,3 +15,7 @@
 <hr />
 
 <%= render @statistics_dashboard.items %>
+
+<hr />
+
+<%= render @statistics_dashboard.contributors %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,12 @@ en:
           queued: 'Queued for processing.'
   statistics:
     dashboard:
+      contributors:
+        table:
+          country: Country
+          institution: Institution
+          items: Items
+        total_html: Contributors &middot; %{total}
       header:
         total_items:
           one: 1 item

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -70,4 +70,51 @@ RSpec.describe StatisticsDashboard do
       end
     end
   end
+
+  describe 'Contributors' do
+    let(:contributors) { dashboard.contributors }
+
+    let(:country1) { { 'value' => 'Country 1', 'count' => '500' } }
+    let(:country2) { { 'value' => 'Country 2', 'count' => '300' } }
+
+    let(:stub_response) do
+      { 'facet_counts' => { 'facet_pivot' => {
+        'agg_provider.en_ssim,agg_provider_country.en_ssim' => [
+          { 'value' => 'Institution 1', 'count' => '500', 'pivot' => [country1] },
+          { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [country2] }
+        ]
+      } } }
+    end
+
+    it { expect(contributors).to be_kind_of(StatisticsDashboard::Contributors) }
+
+    it 'has the total from the total number of institutions in the response' do
+      expect(contributors.total).to be 2
+    end
+
+    it 'has a locale aware provider_field accessor' do
+      expect(contributors.provider_field).to eq 'agg_provider.en_ssim'
+
+      allow(I18n).to receive(:locale).and_return('ar')
+
+      expect(contributors.provider_field).to eq 'agg_provider.ar-Arab_ssim'
+    end
+
+    describe '#institutions' do
+      let(:institutions) { contributors.institutions }
+
+      it { expect(institutions.length).to eq 2 }
+      it { expect(institutions).to all(be_kind_of(StatisticsDashboard::Contributors::Institution)) }
+
+      it 'has a name, an item count, and the country' do
+        expect(institutions.first.name).to eq 'Institution 1'
+        expect(institutions.first.country).to eq 'Country 1'
+        expect(institutions.first.item_count).to eq '500'
+
+        expect(institutions.last.name).to eq 'Institution 2'
+        expect(institutions.last.country).to eq 'Country 2'
+        expect(institutions.last.item_count).to eq '300'
+      end
+    end
+  end
 end

--- a/spec/views/statistics/_contributors.html.erb_spec.rb
+++ b/spec/views/statistics/_contributors.html.erb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'statistics/_contributors.html.erb', type: :view do
+  before do
+    controller.singleton_class.class_eval do
+      include Blacklight::Controller
+    end
+
+    render partial: 'statistics/contributors', locals: {
+      contributors: contributors
+    }
+  end
+
+  let(:stub_response) do
+    { 'facet_counts' => {
+      'facet_pivot' => {
+        'agg_provider.en_ssim,agg_provider_country.en_ssim' => [
+          { 'value' => 'Institution 1', 'count' => '500', 'pivot' => [
+            { 'value' => 'Country 1', 'count' => '500' }
+          ] },
+          { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [
+            { 'value' => 'Country 2', 'count' => '300' }
+          ] }
+        ]
+      }
+    } }
+  end
+
+  let(:contributors) do
+    StatisticsDashboard::Contributors.new(stub_response)
+  end
+
+  it 'has the total number of contributors in the heading' do
+    expect(rendered).to have_css('h2', text: 'Contributors · 2')
+  end
+
+  it 'has a table with each institution, the country, and number of items' do
+    expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: 'Institution 1')
+    expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: 'Country 1')
+    expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: '500')
+
+    expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Institution 2')
+    expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Country 2')
+    expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: '300')
+  end
+
+  it 'links to the institution' do
+    expect(rendered).to have_link('Institution 1', href: /\?f%5Bagg_provider_en%5D%5B%5D=Institution\+1&/)
+    expect(rendered).to have_link('Institution 2', href: /\?f%5Bagg_provider_en%5D%5B%5D=Institution\+2&/)
+  end
+end

--- a/spec/views/statistics/_items.html.erb_spec.rb
+++ b/spec/views/statistics/_items.html.erb_spec.rb
@@ -31,12 +31,7 @@ RSpec.describe 'statistics/_items.html.erb', type: :view do
   end
 
   let(:items) do
-    StatisticsDashboard::Items.new(
-      instance_double(
-        'SearchService',
-        search_results: [stub_response]
-      )
-    )
+    StatisticsDashboard::Items.new(stub_response)
   end
 
   describe 'By type section' do


### PR DESCRIPTION
Closes #688 
<img width="1167" alt="contributors" src="https://user-images.githubusercontent.com/96776/69181432-e8de3a80-0ac3-11ea-8e16-8fec9006d4d8.png">

## Why was this change made?
To add a contributors section to the dashboard.
