### PR TITLE
Solrize date ranges as integers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ config/environments/*.local.yml
 /public/assets/
 
 # Ignore any docker-compose created volume data
-/postgres-data/
 /solr-data/

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'rails', '~> 5.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/projectblacklight/spotlight.git
+  remote: https://github.com/projectblacklight/spotlight.git
   revision: d17659b7a83252f5cf44c22133cdf28f83504ec8
   specs:
     blacklight-spotlight (3.0.0.alpha)
@@ -40,7 +40,7 @@ GIT
       underscore-rails (~> 1.6)
 
 GIT
-  remote: git://github.com/sul-dlss/blacklight-hierarchy.git
+  remote: https://github.com/sul-dlss/blacklight-hierarchy.git
   revision: 8fd4a13209fcaa8ad13df2808edb0e7fcb873f94
   specs:
     blacklight-hierarchy (3.0.0.alpha)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -84,8 +84,8 @@ class CatalogController < ApplicationController
 
     config.add_index_field 'date range', helper_method: :display_date_ranges, values: (lambda do |_field_config, document|
       {
-        gregorian: document.fetch('cho_date_range_norm_ssim', []).map(&:to_i),
-        hijri: document.fetch('cho_date_range_hijri_ssim', []).map(&:to_i)
+        gregorian: document.fetch('cho_date_range_norm_isim', []),
+        hijri: document.fetch('cho_date_range_hijri_isim', [])
       }
     end)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.6'
 
 services:
   app:
@@ -30,8 +30,6 @@ services:
       - "3000:3000"
     depends_on:
       - postgres
-    networks:
-      - dlme
     # For running in dev
     volumes:
       - ".:/opt/"
@@ -43,9 +41,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=sekret
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    networks:
-      - dlme
+      - postgres-data:/var/lib/postgresql/data
   solr:
     image: solr
     ports:
@@ -58,8 +54,6 @@ services:
       - solr-precreate
       - dlme
       - /solr-setup/conf
-    networks:
-      - dlme
   redis:
     image: 'redis:4.0-alpine'
     ports:
@@ -67,8 +61,6 @@ services:
     command: redis-server
     volumes:
       - 'redis:/data'
-    networks:
-      - dlme
   sidekiq:
     depends_on:
       - 'postgres'
@@ -84,8 +76,6 @@ services:
       - '.:/app'
     env_file:
       - '.env'
-    networks:
-      - dlme
     environment:
       - SOLR_URL=http://solr:8983/solr/dlme
       - RAILS_ENV=development
@@ -99,9 +89,6 @@ services:
       - SERVICES=sns,s3
       - DOCKER_HOST=unix:///var/run/docker.sock
       - DEBUG=1
-    networks:
-      - dlme
-networks:
-  dlme:
 volumes:
   redis:
+  postgres-data:

--- a/spec/fixtures/json/iiif-single-image.json
+++ b/spec/fixtures/json/iiif-single-image.json
@@ -25,6 +25,8 @@
   "cho_creator": ["Jane Q. Doe", "John X. Doe"],
   "cho_coverage": ["Egypt"],
   "cho_date": "1977",
+  "cho_date_range_hijri": [1384, 1385, 1386, 1387],
+  "cho_date_range_norm": [1977, 1978, 1979],
   "cho_edm_type": "Image",
   "cho_extent": "1 piece",
   "cho_has_type": "Posters",

--- a/spec/resource_builders/dlme_json_resource_builder_spec.rb
+++ b/spec/resource_builders/dlme_json_resource_builder_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe DlmeJsonResourceBuilder do
         'cho_contributor_ssim' => ['فاتن حمامة', 'محمود ياسين', 'فريد شوقي', 'بركات'],
         'cho_coverage_ssim' => ['Egypt'],
         'cho_date_ssim' => '1977',
+        'cho_date_range_norm_isim' => [1977, 1978, 1979],
+        'cho_date_range_hijri_isim' => [1384, 1385, 1386, 1387],
         'cho_edm_type_ssim' => 'Image',
         'cho_extent_ssim' => '1 piece',
         'cho_has_type_ssim' => 'Posters',


### PR DESCRIPTION
## Why was this change made?

Solrize date ranges as integers. Fixes #697

Also:
* Use https URLs for GitHub-based repositories
* Update docker-compose configuration 
  1. Remove explicit networks (this is not necessary); and
  2. Use a mounted volume in the database container to store data

## Was the documentation (README, API, wiki, ...) updated?

No