### PR TITLE
Add the jumbotron section for contributors

### DIFF
--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -104,6 +104,10 @@ class StatisticsDashboard
       institutions&.count || 0
     end
 
+    def total_countries
+      institutions.collect(&:country).uniq.count
+    end
+
     def institutions
       @institutions ||= (pivot_facets["#{provider_field},#{countries_field}"] || []).collect do |facet|
         Institution.new(facet)

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -1,13 +1,23 @@
 <h1 class="page-title"><%= t('statistics.header') %></h1>
 
-<div class="row d-none d-md-flex justify-content-around">
-  <div class="jumbotron col-4-md">
+<div class="row d-none d-md-flex justify-content-around text-center">
+  <div class="jumbotron">
     <h2 class="display-6">
       <%= t('statistics.dashboard.header.total_items', count: @statistics_dashboard.items.total) %>
     </h2>
     <hr class="my-4">
-    <p class="text-center">
+    <p>
       <%= t('statistics.dashboard.header.total_types', count: @statistics_dashboard.items.by_type.count) %>
+    </p>
+  </div>
+
+  <div class="jumbotron">
+    <h2 class="display-6">
+      <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total) %>
+    </h2>
+    <hr class="my-4">
+    <p>
+      <%= t('statistics.dashboard.header.total_countries', count: @statistics_dashboard.contributors.total_countries) %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,12 @@ en:
           items: Items
         total_html: Contributors &middot; %{total}
       header:
+        total_contributors:
+          one: 1 contributor
+          other: '%{count} contributors'
+        total_countries:
+          one: 1 country
+          other: '%{count} countries'
         total_items:
           one: 1 item
           other: '%{count} items'

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -4,7 +4,21 @@ require 'rails_helper'
 
 RSpec.describe 'Statistics page', type: :feature do
   let(:stub_response) do
-    { 'response' => { 'numFound' => 100 } }
+    {
+      'response' => { 'numFound' => 100 },
+      'facet_counts' => {
+        'facet_pivot' => {
+          'agg_provider.en_ssim,agg_provider_country.en_ssim' => [
+            { 'value' => 'Institution 1', 'count' => '500', 'pivot' => [
+              { 'value' => 'Country 1', 'count' => '500' }
+            ] },
+            { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [
+              { 'value' => 'Country 2', 'count' => '300' }
+            ] }
+          ]
+        }
+      }
+    }
   end
   let(:stub_dashboard) do
     StatisticsDashboard.new(search_service: instance_double(
@@ -16,26 +30,27 @@ RSpec.describe 'Statistics page', type: :feature do
   before do
     create(:exhibit)
     allow(StatisticsDashboard).to receive(:new).and_return(stub_dashboard)
-  end
 
-  it 'has a page available to users via a menu item in the exhibit navbar' do
     visit root_path
 
     within '.exhibit-navbar' do
       click_link 'Statistics'
     end
+  end
 
+  it 'has a page available to users via a menu item in the exhibit navbar' do
     expect(page).to have_css('.exhibit-navbar li.nav-item.active', text: 'Statistics')
     expect(page).to have_css('h1', text: 'Statistics')
   end
 
   it 'has an items section' do
-    visit root_path
-
-    within '.exhibit-navbar' do
-      click_link 'Statistics'
-    end
-
+    expect(page).to have_css('.jumbotron h2', text: '100 items')
     expect(page).to have_css('h2', text: 'Items · 100')
+  end
+
+  it 'has a Contributors section' do
+    expect(page).to have_css('.jumbotron h2', text: '2 contributors')
+    expect(page).to have_css('.jumbotron p', text: '2 countries')
+    expect(page).to have_css('h2', text: 'Contributors · 2')
   end
 end

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe StatisticsDashboard do
       expect(contributors.total).to be 2
     end
 
+    describe '#total_countries' do
+      before do
+        stub_response['facet_counts']['facet_pivot']['agg_provider.en_ssim,agg_provider_country.en_ssim'] << {
+          'value' => 'Institution 3', 'count' => '100', 'pivot' => [country1]
+        }
+      end
+
+      it 'has the total number of unique countries that the institutions are from' do
+        expect(contributors.institutions.count).to eq 3
+        expect(contributors.institutions.last.name).to be 'Institution 3' # validate our new institution is present
+        expect(contributors.total_countries).to eq 2 # Our new institution has the same country as "Institution 1"
+      end
+    end
+
     it 'has a locale aware provider_field accessor' do
       expect(contributors.provider_field).to eq 'agg_provider.en_ssim'
 


### PR DESCRIPTION

<img width="983" alt="contribs-jumbotron" src="https://user-images.githubusercontent.com/96776/69195042-90b53180-0adf-11ea-909c-3f22b7c76d51.png">

In my environment I have the following transforms indexed:
- output-f9967242-f6c2-468e-bb6f-594caed0cf0f.ndjson (from dev)
- output-db22239a-81e4-4118-a667-26fb2b12f889.ndjson (from dev, partially indexed)
- output-12fa7465-adb2-4dc5-b9fd-c302986d45ec.ndjson (from dev, partially indexed)

## Why was this change made?
As a follow on to #688, because, I....uh forgot this part.

![🙈](https://media0.giphy.com/media/ohyNdetcfoJ9K/giphy.gif)
## Was the documentation (README, API, wiki, ...) updated?
