### PR TITLE
Use Mada font (Latin and Arabic scripts) by default for DLME

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import 'variables';
 @import 'spotlight/variables_bootstrap';
 @import 'bootstrap';
+@import 'bootstrap-overrides';
 @import 'blacklight';
 @import 'blacklight_gallery';
 @import 'blacklight_hierarchy';

--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -1,0 +1,3 @@
+@import url('https://fonts.googleapis.com/css?family=Mada&display=swap');
+
+$font-family-base: 'Mada', $font-family-sans-serif;


### PR DESCRIPTION
## Why was this change made?
This change fixes #655 but in a way not originally specified.

### Why?
Great so just load a specific font for a language selector, right this is easy?
https://www.w3.org/International/questions/qa-css-lang

Nope.. so that doesn't work because we need to be more specific. We aren't adding in `lang="ar"` wherever we display different language text.. but we could. But that might be hard.

### Next?
Ok, so we can load fonts for different [unicode ranges](https://developer.mozilla.org/en-US/docs/Web/CSS/%40font-face/unicode-range). And this would be exactly what we want to enable a custom font for [Arabic unicode character ranges](https://en.wikipedia.org/wiki/Arabic_script_in_Unicode). Unfortunately it seems like browser implementation of how unicode range fallbacks work are different (as much as I can tell). Chrome/Safari, everything is good. Firefox no dice, things fallback to the [generic `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) name.

## Solution!
Evaluating several Arabic fonts from Google Web Fonts, I came across [Mada](https://fonts.google.com/specimen/Mada?selection.family=Mada). Mada has both Latin and Arabic glyph support. This gives us the exact behavior we are looking for by having a Latin and Arabic styled font. So going forward.. Mada is our font for everything in DLME. We can add different weights in the future if we need them (for Latin only).

I paired w/ @ggeisler on this and got a 👍 

<img width="1273" alt="Screen Shot 2019-11-19 at 4 29 30 PM" src="https://user-images.githubusercontent.com/1656824/69195757-d37c0700-0ae9-11ea-9859-eeb1657e21cb.png">
<img width="1275" alt="Screen Shot 2019-11-19 at 4 16 12 PM" src="https://user-images.githubusercontent.com/1656824/69195758-d37c0700-0ae9-11ea-909f-d2661d20521c.png">


## Was the documentation (README, API, wiki, ...) updated?
Nope.