### PR TITLE
Fixing the BIDI HTML wrapping

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,8 @@ class CatalogController < ApplicationController
     end
 
     multilingual_locale_aware_field.call('cho_title') do |field_config|
-      config.index.title_field = Blacklight::Configuration::Field.new(first: true, no_html: true, **field_config)
+      config.index.title_field = Blacklight::Configuration::Field.new(first: true, **field_config)
+      config.show.html_title_field = Blacklight::Configuration::Field.new(first: true, no_html: true, **field_config)
     end
 
     config.index.thumbnail_field = 'agg_preview.wr_id_ssim'

--- a/app/processors/bidi_wrap.rb
+++ b/app/processors/bidi_wrap.rb
@@ -12,7 +12,7 @@ class BidiWrap < Blacklight::Rendering::AbstractStep
   private
 
   def wrap(val)
-    return val if options[:no_html]
+    return val if config.no_html
 
     content_tag :bdi, val, class: 'metadata-value'
   end

--- a/spec/processors/bidi_wrap_spec.rb
+++ b/spec/processors/bidi_wrap_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BidiWrap do
     end
 
     context 'when no_html is set' do
-      let(:options) { { no_html: true } }
+      let(:field_config) { Blacklight::Configuration::NullField.new no_html: true }
 
       it 'does nothing' do
         render


### PR DESCRIPTION
## Why was this change made?

- [x] the BIDI wrapping needs to reflect the field configuration, not what's passed in (and it's unclear to me where the join processor gets its `no_html` parameter from..)
- [x] only omit the BIDI tags when rendering title for the `<title>` element.
