### PR TITLE
Disable the masonry view; part of #676

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,7 +18,6 @@ class CatalogController < ApplicationController
 
     config.view.list.partials = %i[thumbnail index_header index]
     config.view.gallery.partials = %i[index_header index]
-    config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]
 
     config.add_results_collection_tool(:sort_widget)


### PR DESCRIPTION
## Why was this change made?

The masonry view we're getting from upstream is not RTL compatible. There may be some work we could do (#713) to make it work, but having this view is not a current requirement.

## Was the documentation (README, API, wiki, ...) updated?
