### PR TITLE
Guard against missing IR data

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -40,7 +40,7 @@ class SolrDocument
   end
 
   def intermediate_representation
-    JSON.parse(fetch('__raw_resource_json_ss'))
+    JSON.parse(fetch('__raw_resource_json_ss', '{}'))
   end
 
   private

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe '#intermediate_representation' do
+    context 'without an IR' do
+      it 'is an empty hash' do
+        expect(document.intermediate_representation).to be_empty
+      end
+    end
+
+    context 'with some data' do
+      let(:source) { { '__raw_resource_json_ss' => { a: 1 }.to_json } }
+
+      it 'returns the raw resource document' do
+        expect(document.intermediate_representation).to include 'a' => 1
+      end
+    end
+  end
+
   describe '#export_as_ir' do
     let(:source) { { '__raw_resource_json_ss' => '{}' } }
 


### PR DESCRIPTION
## Why was this change made?

Non-transformed items (say, an uploaded item) don't have this field.

## Was the documentation (README, API, wiki, ...) updated?
