### PR TITLE
Store CircleCI yarn cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,15 +42,27 @@ jobs:
         name: Bundle Install
         command: bundle check || bundle install
 
-    - run:
-          name: Yarn Install
-          command: yarn install --cache-folder ~/.cache/yarn
-
     # Store bundle cache
     - save_cache:
         key: rails-demo-bundle-v2-{{ checksum "Gemfile.lock" }}
         paths:
         - vendor/bundle
+
+    # Only necessary if app uses webpacker or yarn in some other way
+    - restore_cache:
+        keys:
+          - rails-demo-yarn-{{ checksum "yarn.lock" }}
+          - rails-demo-yarn-
+
+    - run:
+          name: Yarn Install
+          command: yarn install --cache-folder ~/.cache/yarn
+
+    # Store yarn / webpacker cache
+    - save_cache:
+        key: rails-demo-yarn-{{ checksum "yarn.lock" }}
+        paths:
+          - ~/.cache/yarn
 
     - run:
         name: Test prepare


### PR DESCRIPTION
## Why was this change made?
Follow-up to #730. This will hopefully keep our CircleCI builds humming along by caching JS dependencies installed by yarn. 

This change just follows CircleCI's Ruby language guide. 
https://circleci.com/docs/2.0/language-ruby/#config-walkthrough

## Was the documentation (README, API, wiki, ...) updated?
Just the CircleCI config.