### PR TITLE
Use an array of field names for the index title configuration.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -70,7 +70,12 @@ class CatalogController < ApplicationController
     end
 
     multilingual_locale_aware_field.call('cho_title') do |field_config|
-      config.index.title_field = Blacklight::Configuration::Field.new(first: true, **field_config)
+      title_field_pattern = Blacklight::Configuration::Field.new(first: true, **field_config)[:pattern]
+      pref_langs, options = lang_config[I18n.locale]
+
+      config.index.title_field = (Array.wrap(pref_langs) + Array.wrap(options[:default])).compact.uniq.map do |lang|
+        format(title_field_pattern, lang: lang)
+      end
       config.show.html_title_field = Blacklight::Configuration::Field.new(first: true, no_html: true, **field_config)
     end
 

--- a/spec/features/browse_categories_spec.rb
+++ b/spec/features/browse_categories_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Browse Categories', type: :feature do
+  let(:exhibit) { create(:exhibit) }
+  let(:curator) { create(:exhibit_curator, exhibit: exhibit) }
+
+  context 'when logged in as a curator' do
+    before do
+      login_as curator
+    end
+
+    # This test is to make sure we haven't configured the app in a way that breaks this page
+    it 'are available in the admin dashboard' do
+      visit spotlight.exhibit_searches_path(exhibit)
+
+      expect(page).to have_css('h1', text: 'Curation Browse')
+      expect(page).to have_css('h3', text: 'Browse Categories')
+    end
+  end
+end


### PR DESCRIPTION
Spotlight's `Search` model uses blacklight field configurations and injects fields into the `fl` param. 
https://github.com/projectblacklight/spotlight/blob/a8c60279a9c11821e2c262935802d796ab0adfd8/app/models/spotlight/search.rb#L74-L80

Since we set `index.title_field` to a `Blacklight::Configuration::Field` object this causes solr to throw a 400 error.

This may be something we should ultimately fix up-stream, but we can fix it locally here by doing this (although I don't know if this is what we would actually want)