### PR TITLE
Set a max-width for document metadata

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -34,3 +34,7 @@
     }
   }
 }
+
+.document-metadata dd {
+  max-width: 50ch;
+}


### PR DESCRIPTION
Part of #716 and #728 