### PR TITLE
Add the img-thumbnail class to show page images

### DIFF
--- a/app/views/catalog/_show_with_viewer.html.erb
+++ b/app/views/catalog/_show_with_viewer.html.erb
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="thumbnail-viewer col-12 col-md-4">
       <%= link_to document.first('agg_is_shown_at.wr_id_ssim').presence || '#' do %>
-        <%= render_thumbnail_tag(document, {}, suppress_link: true) %>
+        <%= render_thumbnail_tag(document, { class: 'img-thumbnail' }, suppress_link: true) %>
       <% end %>
     </div>
     <div class="metadata col-12 col-md-8">


### PR DESCRIPTION


## Why was this change made?

This ensures the images don't overflow their column.

Before:
<img width="718" alt="Screen Shot 2019-11-22 at 12 56 44" src="https://user-images.githubusercontent.com/111218/69459887-a1f07f00-0d27-11ea-81f6-30a7fd980d31.png">

After:
<img width="671" alt="Screen Shot 2019-11-22 at 12 56 41" src="https://user-images.githubusercontent.com/111218/69459889-a1f07f00-0d27-11ea-9b9f-30cf16e16f54.png">

## Was the documentation (README, API, wiki, ...) updated?
