### PR TITLE
Use .metadata-value instead of the dd to avoid stomping on the bootstrap grid styles

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -35,6 +35,6 @@
   }
 }
 
-.document-metadata dd {
+.document-metadata .metadata-value {
   max-width: 50ch;
 }


### PR DESCRIPTION
Before:
<img width="766" alt="Screen Shot 2019-11-27 at 13 05 21" src="https://user-images.githubusercontent.com/111218/69759304-a4334e80-1116-11ea-8ac0-5fcfa4e714dd.png">

After:
<img width="478" alt="Screen Shot 2019-11-27 at 13 05 14" src="https://user-images.githubusercontent.com/111218/69759299-a0073100-1116-11ea-981a-61d66f9f0201.png">



## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
