### PR TITLE
Do remove blank lines from json before checking ids

### DIFF
--- a/app/controllers/s3_harvester_controller.rb
+++ b/app/controllers/s3_harvester_controller.rb
@@ -26,9 +26,9 @@ class S3HarvesterController < Spotlight::ApplicationController
 
   def any_duplicate_identifiers?
     ids = body.split("\n").map do |json|
-      JSON.parse(json)['id']
+      JSON.parse(json)['id'] unless json.empty?
     end
-
+    ids.reject!(&:nil?).reject!(&:empty?)
     ids.size != ids.uniq.size
   end
 

--- a/app/controllers/s3_harvester_controller.rb
+++ b/app/controllers/s3_harvester_controller.rb
@@ -28,7 +28,7 @@ class S3HarvesterController < Spotlight::ApplicationController
     ids = body.split("\n").map do |json|
       JSON.parse(json)['id'] unless json.empty?
     end
-    ids.reject!(&:nil?).reject!(&:empty?)
+    ids&.reject!(&:nil?)&.reject!(&:empty?)
     ids.size != ids.uniq.size
   end
 


### PR DESCRIPTION
## Why was this change made?

When an transform error is logged in `dlme-transform`, traject inserts a blank line, this strips those blank lines before comparing ids else a `non-unique ids` error is raised.

## Was the documentation (README, API, wiki, ...) updated?
