### PR TITLE
Do not try to index empty lines in the json

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  method-complexity:
+    config:
+      threshold: 6

--- a/app/jobs/fetch_resources_job.rb
+++ b/app/jobs/fetch_resources_job.rb
@@ -17,6 +17,8 @@ class FetchResourcesJob < ApplicationJob
   private
 
   def create_or_update_resource(item, exhibit, index, url)
+    return if item.empty?
+
     json = JSON.parse(item)
     resource = DlmeJson.find_or_initialize_by(url: json['id'], exhibit: exhibit)
     resource.data = { json: item }


### PR DESCRIPTION
## Why was this change made?

Do not try to index empty lines as they fail JSON validation.

