### PR TITLE
Add new language codes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,4 +36,8 @@ acceptable_bcp47_codes:
   - fa-Arab
   - fa-Latn
   - fr
-  - tr
+  - ms
+  - tr-Arab
+  - tr-Latn
+  - ur-Arab
+  - ur-Latn


### PR DESCRIPTION
## Why was this change made?

This adds incoming language codes from dlme-transform in order to keep DLME and DLME-Transform inline with each other for allowed languages.

## Was the documentation (README, API, wiki, ...) updated?
