### PR TITLE
Make sort per page buttons smaller

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -38,3 +38,9 @@
 .document-metadata .metadata-value {
   max-width: 50ch;
 }
+
+#sortAndPerPage {
+  .btn {
+    @extend .btn-sm;
+  }
+}


### PR DESCRIPTION
## Why was this change made?
Closes #763
We _could_ push this upstream to Spotlight? 

### Before
![large buttons](https://user-images.githubusercontent.com/5402927/70104562-4cec1d00-15f3-11ea-8a48-ad05e81fe78f.png)

### After
![small buttons](https://user-images.githubusercontent.com/5402927/70104563-4cec1d00-15f3-11ea-8e22-a14b895154d3.png)

## Was the documentation (README, API, wiki, ...) updated?
N/A