### PR TITLE
Remove the browser default padding for facet hierarchies

### DIFF
--- a/app/assets/stylesheets/facets.scss
+++ b/app/assets/stylesheets/facets.scss
@@ -16,6 +16,7 @@ ul.facet-hierarchy {
     display: inline-block;
     margin-bottom: 6px;
     max-width: calc(100% - 5em);
+    vertical-align: top;
   }
 
   .h-node {

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -95,8 +95,9 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     padding-right: 0.3em;
   }
 
-  // Fix spacing on facet icons/counts
+  // blacklight-hierarchy overrides
   ul.facet-hierarchy {
+    // Fix spacing on facet icons/counts
     .facet-count {
       float: left;
       text-align: left;
@@ -106,12 +107,6 @@ $breadcrumb-item-padding-x: 0.5rem !default;
       margin-left: 0;
       margin-right: -15px;
     }
-  }
-
-  // blacklight-hierarchy overrides
-
-  ul.facet-hierarchy {
-    padding-right: 0;
 
     .h-node {
       padding-left: 0;
@@ -121,6 +116,12 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     .h-leaf {
       margin-left: 0;
       margin-right: 15px;
+    }
+
+    padding-right: 0;
+
+    ul {
+      padding-right: 0;
     }
   }
 }


### PR DESCRIPTION
After:
<img width="298" alt="Screen Shot 2019-12-05 at 06 57 52" src="https://user-images.githubusercontent.com/111218/70246419-97bd8000-172c-11ea-9478-97872cce71ef.png">

<img width="285" alt="Screen Shot 2019-12-05 at 07 23 57" src="https://user-images.githubusercontent.com/111218/70248735-3bf4f600-1730-11ea-8daf-da5fd6ea65e1.png">


## Why was this change made?

Fixes #774? 

## Was the documentation (README, API, wiki, ...) updated?
