### PR TITLE
Guard against missing normalized date fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -84,10 +84,12 @@ class CatalogController < ApplicationController
     end
 
     config.add_index_field 'date range', helper_method: :display_date_ranges, values: (lambda do |_field_config, document|
-      {
-        gregorian: document.fetch('cho_date_range_norm_isim', []),
-        hijri: document.fetch('cho_date_range_hijri_isim', [])
-      }
+      if document.has?('cho_date_range_norm_isim') || document.has?('cho_date_range_hijri_isim')
+        {
+          gregorian: document.fetch('cho_date_range_norm_isim', []),
+          hijri: document.fetch('cho_date_range_hijri_isim', [])
+        }
+      end
     end)
 
     config.add_index_field 'date', field: 'cho_date_ssim'


### PR DESCRIPTION
## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
