### PR TITLE
Display range limit as ltr when in rtl Arabic view fixes #777

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -124,4 +124,10 @@ $breadcrumb-item-padding-x: 0.5rem !default;
       padding-right: 0;
     }
   }
+
+  .limit_content.range_limit{
+    .profile, form.range_limit {
+      direction: ltr;
+    }
+  }
 }


### PR DESCRIPTION
## Why was this change made?
To fix #777 

<img width="1023" alt="Screen Shot 2019-12-09 at 3 27 57 PM" src="https://user-images.githubusercontent.com/1656824/70478567-8a8bf280-1a98-11ea-8f8f-e930b6fa6e47.png">
<img width="272" alt="Screen Shot 2019-12-09 at 3 27 47 PM" src="https://user-images.githubusercontent.com/1656824/70478569-8a8bf280-1a98-11ea-9139-d0ae1f45379d.png">

