### PR TITLE
Add 700 weight to font stack to get bold

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Mada&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Mada:400,700&display=swap');
 
 $font-family-base: 'Mada', $font-family-sans-serif;
 


### PR DESCRIPTION
## Why was this change made?
There are places in the exhibit where certain elements are specified to be displayed in bold. Here's a couple of examples:

<img width="867" alt="Screen Shot 2019-12-10 at 10 10 05 AM" src="https://user-images.githubusercontent.com/101482/70551830-895cd300-1b35-11ea-8f14-5cd26d3dadcc.png">

---

Current DLME doesn't show those as bold because the font stack doesn't include a heavier weight version of the Mada font, so we get this:

<img width="972" alt="Screen Shot 2019-12-10 at 10 06 30 AM" src="https://user-images.githubusercontent.com/101482/70551947-b9a47180-1b35-11ea-9460-2dd015a2fc61.png">

### After
With this PR, DLME will look more like this:

<img width="972" alt="Screen Shot 2019-12-10 at 10 07 20 AM" src="https://user-images.githubusercontent.com/101482/70552003-ce810500-1b35-11ea-89b0-842f0de775dd.png">


## Was the documentation (README, API, wiki, ...) updated?
N/A