### PR TITLE
Add cache_with_locale; fixes #809

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,3 +100,5 @@ gem 'bootstrap', '~> 4.0'
 gem 'font-awesome-rails'
 
 gem 'webpacker', '~> 4.x'
+
+gem 'cache_with_locale'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     breadcrumbs_on_rails (3.0.1)
     builder (3.2.4)
     byebug (11.0.1)
+    cache_with_locale (0.0.1)
+      rails
     cancancan (3.0.1)
     capybara (3.29.0)
       addressable
@@ -595,6 +597,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.0)
   byebug
+  cache_with_locale
   capybara (~> 3.0)
   carrierwave-aws
   coffee-rails (~> 4.2)


### PR DESCRIPTION
Fixes #809 by using the locale as part of the cache key

[cache_with_locale](https://github.com/igorkasyanchuk/cache_with_locale)

> Automatically adding current application locale (I18n.locale) as a part of caching key in Rails views.
