### PR TITLE
Disable exporting resources or solr documents as part of the export process

### DIFF
--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -78,3 +78,5 @@ Spotlight::Engine.config.ga_email = Settings.analytics.email
 Spotlight::Engine.config.routes.solr_documents = {
   constraints: { id: %r{.+} }
 }
+
+Spotlight::Engine.config.exports[:resources] = false


### PR DESCRIPTION
## Why was this change made?

Hopefully this will avoid the timeout issues we were seeing and let us get exhibit content out easily.

## Was the documentation (README, API, wiki, ...) updated?
