### PR TITLE
BIDI isolate the document counter so it isn't influenced by the directionality of the title

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -10,6 +10,10 @@ $breadcrumb-item-padding-x: 0.5rem !default;
   unicode-bidi: plaintext;
 }
 
+.document-counter {
+  unicode-bidi: isolate;
+}
+
 .rtl,
 [dir="rtl"] {
   /** The upstream stylsheet doesn't expect dir="rtl" on the <html> element.. */


### PR DESCRIPTION
fixes #729

<img width="587" alt="Screen Shot 2019-12-16 at 11 13 06" src="https://user-images.githubusercontent.com/111218/70935460-0b953d80-1ff5-11ea-951a-2f962a90be46.png"/>
