### PR TITLE
Setup contextual alert dismissable for search results fixes #805

### DIFF
--- a/app/controllers/session_displays_controller.rb
+++ b/app/controllers/session_displays_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# A controller for disabling session information
+class SessionDisplaysController < ApplicationController
+  ##
+  # Update the session, to disable_search_context
+  def update
+    session[:disable_search_context] = true
+    redirect_to request.referer
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,10 @@ module ApplicationHelper
     safe_join(values, '<br />'.html_safe) if values.any?
   end
 
+  def display_search_context?
+    !session[:disable_search_context]
+  end
+
   private
 
   def display_date_range(gregorian_dates:, hijri_dates:)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -3,6 +3,7 @@
 # Override Blacklight-provided helpers
 module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
+  include Blacklight::RenderPartialsHelperBehavior
 
   # Override Blacklight's html_tag_attributes helper
   # to set the correct HTML dir attribute for Arabic
@@ -11,5 +12,15 @@ module BlacklightHelper
     attr[:dir] = 'rtl' if I18n.locale == :ar
 
     attr
+  end
+
+  # Overidden from Blacklight to provide contextual information
+  def render_document_index(documents = nil, locals = {})
+    safe_join(
+      [
+        *(render('shared/contextual_result_info') if display_search_context?),
+        super(documents, locals)
+      ]
+    )
   end
 end

--- a/app/views/shared/_contextual_result_info.html.erb
+++ b/app/views/shared/_contextual_result_info.html.erb
@@ -1,6 +1,9 @@
 <div class="alert alert-info alert-dismissible fade show" role="alert">
   <p>
-    <%= t('contextual_result_info.body') %>
+    <%= t(
+      'contextual_result_info.body_html',
+      link: exhibit_about_page_path(current_exhibit, Settings.searching_site_slug)
+    ) %>
   </p>
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>

--- a/app/views/shared/_contextual_result_info.html.erb
+++ b/app/views/shared/_contextual_result_info.html.erb
@@ -1,0 +1,20 @@
+<div class="alert alert-info alert-dismissible fade show" role="alert">
+  <p>
+    <%= t('contextual_result_info.body') %>
+  </p>
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <div class="text-right">
+    <button type="button" class="btn btn-outline-secondary" data-dismiss="alert">
+      <%= t('contextual_result_info.dismiss') %>
+    </button>
+    <%= button_to(
+      t('contextual_result_info.disable_session'),
+      session_display_path,
+      method: :patch,
+      class: 'btn btn-outline-primary',
+      remote: true)
+    %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   contextual_result_info:
-    body: You might see more results for your query by entering your search terms in another language.
+    body_html: "You might see more results for your query by <a href='%{link}'>entering your search terms in another language<a>."
     dismiss: Dismiss
     disable_session: Don't show again
   footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  contextual_result_info:
+    body: You might see more results for your query by entering your search terms in another language.
+    dismiss: Dismiss
+    disable_session: Don't show again
   footer:
     partnership_heading: In partnership with
     project_support_heading: Project supported by

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     devise_for :users
     mount Blacklight::Oembed::Engine, at: 'oembed'
     mount Riiif::Engine => '/images', as: 'riiif'
+    resource :session_display, only: :update
 
     resources :suggest, only: :index, defaults: { format: 'json' }
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,8 @@ allow_robots: false
 feature_flags:
   allow_json_upload: false
 
+searching_site_slug: 'searching-this-site'
+
 acceptable_bcp47_codes:
   - ar-Arab
   - ar-Latn

--- a/spec/controllers/session_displays_controller_spec.rb
+++ b/spec/controllers/session_displays_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionDisplaysController do
+  before do
+    request.env['HTTP_REFERER'] = '/'
+  end
+
+  describe 'PATCH update' do
+    it 'redirects back to referer' do
+      patch :update, params: {}
+      expect(response).to redirect_to('/')
+    end
+
+    it 'sets the disable_search_context to true' do
+      expect(session[:disable_search_context]).to be_falsey
+      patch :update, params: {}
+      expect(session[:disable_search_context]).to eq true
+    end
+  end
+end

--- a/spec/features/contextual_message_spec.rb
+++ b/spec/features/contextual_message_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'Contextual message on search results', type: :feature do
     click_button 'Search'
   end
 
+  it 'contains a link to contextual page' do
+    within '#content .alert-info' do
+      expect(page).to have_css 'a', text: 'entering your search terms in another language'
+    end
+  end
+
   it 'renders info alert, that is dismissable', js: true do
     within '#content' do
       expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'

--- a/spec/features/contextual_message_spec.rb
+++ b/spec/features/contextual_message_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Contextual message on search results', type: :feature do
+  let(:exhibit) { create(:exhibit, published: true) }
+  let(:resource) { DlmeJson.new(json: json, metadata: metadata, exhibit: exhibit) }
+  let(:fixture_file_path) { File.join(fixture_path, 'json/bodleian.json') }
+  let(:json) { File.open(fixture_file_path).read }
+  let(:metadata) do
+    { 'traject_context_command_line.filename' => fixture_file_path,
+      'traject_context_source' => 'dlme_json_resource_spec' }
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :inline # block until indexing has committed
+    resource.save_and_index
+    visit root_path
+    click_button 'Search'
+  end
+
+  it 'renders info alert, that is dismissable', js: true do
+    within '#content' do
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+      click_button 'Dismiss'
+      expect(page).not_to have_css '.alert.alert-info'
+    end
+    click_button 'Search'
+    within '#content' do
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+    end
+  end
+
+  it 'renders info alert, that is not shown again in the session', js: true do
+    within '#content' do
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+      click_button 'Don\'t show again'
+      expect(page).not_to have_css '.alert.alert-info'
+    end
+    click_button 'Search'
+    within '#content' do
+      expect(page).not_to have_css '.alert.alert-info', text: 'You might see more results for your query'
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
To fix #805

![alert](https://user-images.githubusercontent.com/1656824/71005324-b57dd400-20a0-11ea-94ee-891d604137a4.gif)


## Unanswered question
I'm not sure how we are going to provide a link within this alert to a user created about page. Any thoughts?

