### PR TITLE
Update typography of main menu

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -94,6 +94,23 @@ body {
   white-space: normal;
 }
 
+.image-masthead .navbar .navbar-nav .nav-link {
+  letter-spacing: 0.5px;
+  padding-left: 12px;
+  padding-right: 12px;
+  text-transform: uppercase;
+}
+
+.image-masthead .navbar .navbar-nav .nav-link,
+.topbar .navbar-nav .nav-link {
+  color: $color-gray-medium;
+
+  &:hover,
+  &:focus {
+    color: $color-gray-light;
+  }
+}
+
 .facet-limit-active {
   border-color: $color-gray-medium !important;
 


### PR DESCRIPTION
The typography of the main menu nav items is currently not too great, with somewhat small text (for an important menu, anyway) and dim colors. This PR updates the typography to address those issues (though further improvements might be coming when I get to the final visual design of the site). It also lightens the text color of the menu items in the topbar.

### Before
<img width="1005" alt="Screen Shot 2019-12-18 at 4 28 12 PM" src="https://user-images.githubusercontent.com/101482/71132194-134f1080-21b4-11ea-871a-eb58aaf32f43.png">



### After
<img width="1005" alt="Screen Shot 2019-12-18 at 4 28 32 PM" src="https://user-images.githubusercontent.com/101482/71132131-e3077200-21b3-11ea-86df-340adbec22cb.png">

