### PR TITLE
Update stats page jumbotron and heading sizes

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -40,6 +40,18 @@ body {
   }
 }
 
+/* Statistics page styling */
+.blacklight-statistics-show {
+  .jumbotron {
+    border: 1px solid $color-gray-medium;
+    margin-top: $padding-large-vertical;
+
+    @media (min-width: 576px) {
+      padding: 2rem;
+    }
+  }
+}
+
 /* overrides for visual design changes */
 .btn-primary {
   @include button-variant($color-black-light, $color-black-light);

--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('statistics.dashboard.contributors.total_html', total: contributors.total) %></h2>
+<h2 class="h3"><%= t('statistics.dashboard.contributors.total_html', total: contributors.total) %></h2>
 
 <table class="table table-striped contributors">
   <thead>

--- a/app/views/statistics/_items.html.erb
+++ b/app/views/statistics/_items.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('statistics.dashboard.items.total_html', total: items.total) %></h2>
+<h2 class="h3"><%= t('statistics.dashboard.items.total_html', total: items.total) %></h2>
 <div class="row">
   <div class="col-6">
     <table class="table table-striped by-type">

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -1,8 +1,8 @@
-<h1 class="page-title"><%= t('statistics.header') %></h1>
+<h1 class="page-title h2"><%= t('statistics.header') %></h1>
 
 <div class="d-none d-md-flex justify-content-around text-center">
   <div class="jumbotron col-3">
-    <h2 class="display-6">
+    <h2 class="h4">
       <%= t('statistics.dashboard.header.total_collections', count: @statistics_dashboard.collections.total) %>
     </h2>
     <hr class="my-4">
@@ -12,7 +12,7 @@
   </div>
 
   <div class="jumbotron col-3">
-    <h2 class="display-6">
+    <h2 class="h4">
       <%= t('statistics.dashboard.header.total_items', count: @statistics_dashboard.items.total) %>
     </h2>
     <hr class="my-4">
@@ -22,7 +22,7 @@
   </div>
 
   <div class="jumbotron col-3">
-    <h2 class="display-6">
+    <h2 class="h4">
       <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total) %>
     </h2>
     <hr class="my-4">


### PR DESCRIPTION
Just some minor styling updates to reduce height of jumbotrons and reduce section heading sizes a bit.

### Before
<img width="969" alt="Screen Shot 2019-12-18 at 5 09 49 PM" src="https://user-images.githubusercontent.com/101482/71133912-7f804300-21b9-11ea-8152-36aafa43cbdb.png">



### After
<img width="969" alt="Screen Shot 2019-12-18 at 5 10 09 PM" src="https://user-images.githubusercontent.com/101482/71133899-78593500-21b9-11ea-8712-abbadfb910d0.png">

