### PR TITLE
Update styling of Analytics > User Activity table

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -9,6 +9,18 @@
   padding-left: 10px;
 }
 
+/* Curation > Analytics user activity table */
+.table.analytics {
+  background-color: $color-gray-light;
+
+  .value {
+    color: $color-black-medium;
+    font-size: $h2-font-size;
+    font-weight: 700;
+    padding-bottom: 0;
+  }
+}
+
 /* override blacklight to hide the sidebar */
 .blacklight-catalog-show {
   #content {


### PR DESCRIPTION
## Why was this change made?

The analytics numbers should be more prominent, so they catch the curator's attention and are more readable at a glance.

### Before
<img width="969" alt="Screen Shot 2019-12-19 at 4 53 36 PM" src="https://user-images.githubusercontent.com/101482/71218977-c5540e80-2280-11ea-9d67-b52519383f32.png">

### After
<img width="969" alt="Screen Shot 2019-12-19 at 4 49 05 PM" src="https://user-images.githubusercontent.com/101482/71218983-cd13b300-2280-11ea-8067-0b37315611c2.png">
