### PR TITLE
Display fields on the facet configuration page regardless of locale.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -80,8 +80,14 @@ class CatalogController < ApplicationController
     config.add_index_field 'spatial', **multilingual_locale_aware_field('cho_spatial')
     config.add_index_field 'temporal', **multilingual_locale_aware_field('cho_temporal')
 
-    arabic_locale = ->(*_) { I18n.locale == :ar }
-    en_locale = ->(*_) { I18n.locale == :en }
+    arabic_locale = lambda do |context, *_|
+      context.is_a?(Spotlight::SearchConfigurationsController) ||
+        I18n.locale == :ar
+    end
+    en_locale = lambda do |context, *_|
+      context.is_a?(Spotlight::SearchConfigurationsController) ||
+        I18n.locale == :en
+    end
 
     config.add_facet_field 'language_ar',    field: 'cho_language.ar-Arab_ssim', limit: true, if: arabic_locale
     config.add_facet_field 'language_en',    field: 'cho_language.en_ssim', limit: true, if: en_locale


### PR DESCRIPTION
Closes #843 (or at least is a temp. workaround)

## Why was this change made?
We currently configure a different facet field for each locale a user might use (en, ar) and display that based on the current locale.  This is also extending to the admin page.  This means that currently re-ordering / enabling / disabling facets in the admin under the English locale does not affect the display of the Arabic facets in the Arabic display.  There also appears to be an issue w/ the Spotlight code that is dropping some attributes from the config when the form is saved **without** that field in the page/form (illustrated in the gif below).

### Current
![facets-bug](https://user-images.githubusercontent.com/96776/71299006-c009c900-233f-11ea-986a-d356c68e16e7.gif)

This PR allows the fields for each locale to show up on the `Spotlight::SearchConfigurationsController` (which is where facets are configured) which gets us around the dropping of data and/or needing to make certain configurations in the admin interface in Arabic.

<img width="863" alt="Screen Shot 2019-12-20 at 3 49 55 PM" src="https://user-images.githubusercontent.com/96776/71299142-ae74f100-2340-11ea-967e-2440ef6236dc.png">
