### PR TITLE
Don't send not-found errors to honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,3 @@
+exceptions:
+  ignore:
+    - 'Blacklight::Exceptions::RecordNotFound'


### PR DESCRIPTION
## Why was this change made?
Currently we're logging 404s to honeybadger, but these need not be logged.

## Was the documentation (README, API, wiki, ...) updated?

no.
