### PR TITLE
Update the range limit plugin and configure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight.git
-  revision: 552f2ddc8f229883f284897a0367addcf3a8e171
+  revision: 8ff188b82424017db0d93ea9151ad9c38ed6f65e
   specs:
-    blacklight-spotlight (3.0.0.alpha.8)
+    blacklight-spotlight (3.0.0.alpha.9)
       acts-as-taggable-on (>= 5.0, < 7)
       almond-rails (~> 0.1)
       autoprefixer-rails
@@ -94,7 +94,7 @@ GEM
     autoprefixer-rails (9.7.5)
       execjs
     aws-eventstream (1.0.3)
-    aws-partitions (1.290.0)
+    aws-partitions (1.293.0)
     aws-sdk-core (3.92.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -137,7 +137,7 @@ GEM
       blacklight (~> 7.0)
       rails
       ruby-oembed
-    blacklight_range_limit (7.6.0)
+    blacklight_range_limit (7.7.0)
       blacklight (>= 7.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -162,16 +162,16 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    carrierwave (2.0.2)
+    carrierwave (2.1.0)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       addressable (~> 2.6)
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
-    carrierwave-aws (1.4.0)
+    carrierwave-aws (1.5.0)
       aws-sdk-s3 (~> 1.0)
-      carrierwave (>= 0.7, < 2.1)
+      carrierwave (~> 2.0)
     childprocess (3.0.0)
     clipboard-rails (1.7.1)
     coffee-rails (4.2.2)
@@ -279,8 +279,8 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    iiif-image-api (0.1.0)
-      activesupport (<= 6)
+    iiif-image-api (0.2.0)
+      activesupport
     iiif-presentation (0.2.0)
       activesupport (>= 3.2.18)
       faraday (>= 0.9)
@@ -427,9 +427,9 @@ GEM
       railties (>= 5.0)
     retriable (3.1.2)
     rexml (3.2.4)
-    riiif (2.2.0)
+    riiif (2.3.0)
       deprecation (>= 1.0.0)
-      iiif-image-api (~> 0.1.0)
+      iiif-image-api (>= 0.1.0)
       railties (>= 4.2, < 7)
     roar (1.1.0)
       representable (~> 3.0.0)
@@ -462,17 +462,17 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.5.0)
+    rubocop-rails (2.5.1)
       activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -511,7 +511,7 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
-    signet (0.13.2)
+    signet (0.14.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
@@ -572,7 +572,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (4.2.0)
@@ -581,7 +581,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)

--- a/app/assets/javascripts/range_limit_config.js
+++ b/app/assets/javascripts/range_limit_config.js
@@ -1,0 +1,12 @@
+Blacklight.onLoad(function() {
+  var dateRangeFacets = [
+    $('.blacklight-cho_date_range_norm_isim'),
+    $('.blacklight-cho_date_range_hijri_isim')
+  ];
+
+  for(i = 0; i < dateRangeFacets.length; i++) {
+    dateRangeFacets[i].data('plot-config', {
+      selection: { displaySelectionDecorations: false }
+    });
+  }
+});


### PR DESCRIPTION
## Why was this change made?
To wrap up work on #765, primarily configuring flot to no longer display the selection decorations/handles on the year histogram.

## Was the documentation (README, API, wiki, ...) updated?
n/a

## Before
<img width="271" alt="facets-before" src="https://user-images.githubusercontent.com/96776/78307120-128b8180-74fa-11ea-907b-42b0709feb4f.png">

## After
<img width="280" alt="facets-after" src="https://user-images.githubusercontent.com/96776/78307125-13241800-74fa-11ea-831d-4bfe7d35c1db.png">
