### PR TITLE
BIDI isolate browse category titles so they flow right in mixed-langu…

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -6,6 +6,8 @@ $breadcrumb-item-padding-x: 0.5rem !default;
 .filter-value,
 .tooltip-inner,
 .document-metadata dd,
+.browse-category-title,
+.blacklight-browse-show h1 .title,
 .index_title a {
   unicode-bidi: plaintext;
 }


### PR DESCRIPTION
…age modes

Fixes #834 (with https://github.com/projectblacklight/spotlight/pull/2508)

Before:
![Screen Shot 2020-04-02 at 13 40 43](https://user-images.githubusercontent.com/111218/78298668-92f4b700-74e7-11ea-951d-c00586fcaf18.png)


After:
![Screen Shot 2020-04-02 at 13 40 15](https://user-images.githubusercontent.com/111218/78298619-82dcd780-74e7-11ea-9080-b3e21fcab7bf.png)
