### PR TITLE
Allow contributing institutions to exist in more than one country.

### DIFF
--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -163,7 +163,7 @@ class StatisticsDashboard
     end
 
     def total_countries
-      institutions.collect(&:country).uniq.count
+      institutions.collect(&:countries).flatten.uniq.count
     end
 
     def institutions
@@ -192,8 +192,8 @@ class StatisticsDashboard
         facet['value']
       end
 
-      def country
-        country_facet&.[]('value')
+      def countries
+        facet&.[]('pivot')&.map { |country| country['value'] }
       end
 
       def collection_count

--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -13,7 +13,7 @@
     <% contributors.institutions.each do |institution| %>
       <tr>
         <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name) %></td>
-        <td><%= institution.country %></td>
+        <td><%= institution.countries.join(', ') %></td>
         <td class="text-right"><%= institution.collection_count %></td>
         <td class="text-right"><%= institution.item_count %></td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
       contributors:
         table:
           collections: Collections
-          country: Country
+          country: Countries
           institution: Institution
           items: Items
         total_html: Contributors &middot; %{total}

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -146,17 +146,30 @@ RSpec.describe StatisticsDashboard do
 
       it 'has a name, an item count, and the country' do
         expect(institutions.first.name).to eq 'Institution 1'
-        expect(institutions.first.country).to eq 'Country 1'
+        expect(institutions.first.countries).to eq ['Country 1']
         expect(institutions.first.item_count).to eq '500'
 
         expect(institutions.last.name).to eq 'Institution 2'
-        expect(institutions.last.country).to eq 'Country 2'
+        expect(institutions.last.countries).to eq ['Country 2']
         expect(institutions.last.item_count).to eq '300'
       end
 
       it 'has a collection count that adds all the collection numbers' do
         expect(institutions.first.collection_count).to eq 3
         expect(institutions.last.collection_count).to eq 1
+      end
+
+      context 'when an institution is in multiple countries' do
+        let(:country4) { { 'value' => 'Country 4', 'count' => '17', 'pivot' => [{ value: 'coll/4', 'count' => '17' }] } }
+
+        before do
+          pivot_field = 'agg_provider.en_ssim,agg_provider_country.en_ssim,agg_data_provider_collection_ssim'
+          stub_response['facet_counts']['facet_pivot'][pivot_field][0]['pivot'] << country4
+        end
+
+        it 'returns them in the countries accessor' do
+          expect(institutions.first.countries).to eq ['Country 1', 'Country 4']
+        end
       end
     end
   end

--- a/spec/views/statistics/_contributors.html.erb_spec.rb
+++ b/spec/views/statistics/_contributors.html.erb_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'statistics/_contributors.html.erb', type: :view do
             { 'value' => 'Country 1', 'count' => '500', 'pivot' => %w[Does Not Matter] }
           ] },
           { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [
-            { 'value' => 'Country 2', 'count' => '300', 'pivot' => ['thing'] }
+            { 'value' => 'Country 2', 'count' => '200', 'pivot' => ['thing'] },
+            { 'value' => 'Country 3', 'count' => '100', 'pivot' => ['thing'] }
           ] }
         ]
       }
@@ -44,6 +45,10 @@ RSpec.describe 'statistics/_contributors.html.erb', type: :view do
     expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Institution 2')
     expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Country 2')
     expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: '300')
+  end
+
+  it 'comma separates multiple countries' do
+    expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Country 2, Country 3')
   end
 
   it 'includes the collection count' do


### PR DESCRIPTION
Closes #883 

## Why was this change made?
Institutions can exist in multiple countries so we need to display all of them in the dashboard (we were using just the first returned in the pivot facet response for display).

## Was the documentation (README, API, wiki, ...) updated?
n/a

Using the AIMS transform from dev on 3/12/2020

## Before
<img width="1146" alt="contributors-before" src="https://user-images.githubusercontent.com/96776/78299845-65117180-74eb-11ea-92d9-87351db98da0.png">

## After
<img width="1145" alt="contributors-after" src="https://user-images.githubusercontent.com/96776/78302109-0a7a1480-74ef-11ea-9472-4809aea04ce7.png">

