### PR TITLE
Use number_with_delimeter helper on statistics page to add commas

### DIFF
--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h3"><%= t('statistics.dashboard.contributors.total_html', total: contributors.total) %></h2>
+<h2 class="h3"><%= t('statistics.dashboard.contributors.total_html', total: number_with_delimiter(contributors.total)) %></h2>
 
 <table class="table table-striped contributors">
   <thead>
@@ -14,8 +14,8 @@
       <tr>
         <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name) %></td>
         <td><%= institution.countries.join(', ') %></td>
-        <td class="text-right"><%= institution.collection_count %></td>
-        <td class="text-right"><%= institution.item_count %></td>
+        <td class="text-right"><%= number_with_delimiter(institution.collection_count) %></td>
+        <td class="text-right"><%= number_with_delimiter(institution.item_count) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/statistics/_items.html.erb
+++ b/app/views/statistics/_items.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h3"><%= t('statistics.dashboard.items.total_html', total: items.total) %></h2>
+<h2 class="h3"><%= t('statistics.dashboard.items.total_html', total: number_with_delimiter(items.total)) %></h2>
 <div class="row">
   <div class="col-6">
     <table class="table table-striped by-type">
@@ -16,7 +16,7 @@
                 <%= facet_display_value(items.type_facet, field['value']) %>
               <% end %>
             </td>
-            <td class="text-right"><%= field['count'] %></td>
+            <td class="text-right"><%= number_with_delimiter(field['count']) %></td>
           </tr>
           <% field['pivot'].each do |pivot| %>
             <tr>
@@ -25,7 +25,7 @@
                   <%= facet_display_value(items.type_facet, pivot['value']) %>
                 <% end %>
               </td>
-              <td class="text-right"><%= pivot['count'] %></td>
+              <td class="text-right"><%= number_with_delimiter(pivot['count']) %></td>
             </tr>
           <% end if field['pivot'] %>
         <% end %>
@@ -48,7 +48,7 @@
                 <%= facet_display_value(items.language_field, field['value']) %>
               <% end %>
             </td>
-            <td class="text-right"><%= field['count'] %></td>
+            <td class="text-right"><%= number_with_delimiter(field['count']) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/statistics/show.html.erb
+++ b/app/views/statistics/show.html.erb
@@ -3,31 +3,31 @@
 <div class="d-none d-md-flex justify-content-around text-center">
   <div class="jumbotron col-3">
     <h2 class="h4">
-      <%= t('statistics.dashboard.header.total_collections', count: @statistics_dashboard.collections.total) %>
+      <%= t('statistics.dashboard.header.total_collections', count: @statistics_dashboard.collections.total, formatted_count: number_with_delimiter(@statistics_dashboard.collections.total)) %>
     </h2>
     <hr class="my-4">
     <p>
-      <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total) %>
+      <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total, formatted_count: number_with_delimiter(@statistics_dashboard.contributors.total)) %>
     </p>
   </div>
 
   <div class="jumbotron col-3">
     <h2 class="h4">
-      <%= t('statistics.dashboard.header.total_items', count: @statistics_dashboard.items.total) %>
+      <%= t('statistics.dashboard.header.total_items', count: @statistics_dashboard.items.total, formatted_count: number_with_delimiter(@statistics_dashboard.items.total)) %>
     </h2>
     <hr class="my-4">
     <p>
-      <%= t('statistics.dashboard.header.total_types', count: @statistics_dashboard.items.by_type.count) %>
+      <%= t('statistics.dashboard.header.total_types', count: @statistics_dashboard.items.by_type.count, formatted_count: number_with_delimiter(@statistics_dashboard.items.by_type.count)) %>
     </p>
   </div>
 
   <div class="jumbotron col-3">
     <h2 class="h4">
-      <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total) %>
+      <%= t('statistics.dashboard.header.total_contributors', count: @statistics_dashboard.contributors.total, formatted_count: number_with_delimiter(@statistics_dashboard.contributors.total)) %>
     </h2>
     <hr class="my-4">
     <p>
-      <%= t('statistics.dashboard.header.total_countries', count: @statistics_dashboard.contributors.total_countries) %>
+      <%= t('statistics.dashboard.header.total_countries', count: @statistics_dashboard.contributors.total_countries, formatted_count: number_with_delimiter(@statistics_dashboard.contributors.total_countries)) %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,19 +60,19 @@ en:
       header:
         total_collections:
           one: 1 collection
-          other: "%{count} collections"
+          other: "%{formatted_count} collections"
         total_contributors:
           one: 1 contributor
-          other: "%{count} contributors"
+          other: "%{formatted_count} contributors"
         total_countries:
           one: 1 country
-          other: "%{count} countries"
+          other: "%{formatted_count} countries"
         total_items:
           one: 1 item
-          other: "%{count} items"
+          other: "%{formatted_count} items"
         total_types:
           one: 1 item type
-          other: "%{count} item types"
+          other: "%{formatted_count} item types"
       items:
         by_language: By language
         by_type: By type

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Statistics page', type: :feature do
   let(:stub_response) do
     {
-      'response' => { 'numFound' => 100 },
+      'response' => { 'numFound' => 100_000 },
       'facet_counts' => {
         'facet_fields' => {
           'agg_data_provider_collection_ssim' => ['Value 1', '500', 'Value 2', '300']
@@ -53,8 +53,8 @@ RSpec.describe 'Statistics page', type: :feature do
   end
 
   it 'has an items section' do
-    expect(page).to have_css('.jumbotron h2', text: '100 items')
-    expect(page).to have_css('h2', text: 'Items · 100')
+    expect(page).to have_css('.jumbotron h2', text: '100,000 items')
+    expect(page).to have_css('h2', text: 'Items · 100,000')
   end
 
   it 'has a Contributors section' do

--- a/spec/views/statistics/_contributors.html.erb_spec.rb
+++ b/spec/views/statistics/_contributors.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'statistics/_contributors.html.erb', type: :view do
     { 'facet_counts' => {
       'facet_pivot' => {
         'agg_provider.en_ssim,agg_provider_country.en_ssim,agg_data_provider_collection_ssim' => [
-          { 'value' => 'Institution 1', 'count' => '500', 'pivot' => [
+          { 'value' => 'Institution 1', 'count' => '5000', 'pivot' => [
             { 'value' => 'Country 1', 'count' => '500', 'pivot' => %w[Does Not Matter] }
           ] },
           { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [
@@ -40,7 +40,7 @@ RSpec.describe 'statistics/_contributors.html.erb', type: :view do
   it 'has a table with each institution, the country, and number of items' do
     expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: 'Institution 1')
     expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: 'Country 1')
-    expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: '500')
+    expect(rendered).to have_css('table tbody tr:nth-child(1) td', text: '5,000')
 
     expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Institution 2')
     expect(rendered).to have_css('table tbody tr:nth-child(2) td', text: 'Country 2')


### PR DESCRIPTION
Fixes #915

## Before
<img width="811" alt="Screen Shot 2020-04-06 at 1 49 27 PM" src="https://user-images.githubusercontent.com/1656824/78598957-76b98880-780d-11ea-8cdb-a93480df8d55.png">

## After
<img width="863" alt="Screen Shot 2020-04-06 at 1 49 11 PM" src="https://user-images.githubusercontent.com/1656824/78598959-77eab580-780d-11ea-945d-33508b95ed83.png">
