### PR TITLE
Allow the raw doc to be accessed using a query parameter

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,4 +207,12 @@ class CatalogController < ApplicationController
 
     config.add_field_configuration_to_solr_request!
   end
+
+  def show
+    if params[:raw]
+      raw
+    else
+      super
+    end
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CatalogController do
+  render_views
+
+  let(:search_service) { instance_double(Blacklight::SearchService) }
+
+  before do
+    allow(controller).to receive(:search_service).and_return(search_service)
+  end
+
+  describe 'GET show' do
+    let(:search_service) { instance_double(Blacklight::SearchService, fetch: [double, doc]) }
+    let(:doc) { SolrDocument.new(id: 'xyz') }
+
+    context 'with the raw query param' do
+      it 'returns the raw solr document' do
+        get :show, params: { id: 'xyz', raw: true }
+
+        expect(response).to be_successful
+        expect(JSON.parse(response.body).with_indifferent_access).to include(id: 'xyz')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #922 by making the raw endpoint accessible with e.g. `?raw=true`.