### PR TITLE
Use the right qf parameters for title searches

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -192,7 +192,7 @@ class CatalogController < ApplicationController
     config.add_search_field 'all_fields', label: 'Everything'
     config.add_search_field 'title', label: 'Title' do |field|
       field.solr_local_parameters = {
-        qf: '$qf_title'
+        qf: '$title_qf'
       }
     end
     config.add_search_field 'author', label: 'Creator / Contributor' do |field|


### PR DESCRIPTION
## Why was this change made?

Assuming https://github.com/sul-dlss/dlme/blob/master/solr/config/solrconfig.xml#L92 matches what's in production, this configuration was wrong,

