### PR TITLE
Stop using local params for solr query parameters

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -191,13 +191,13 @@ class CatalogController < ApplicationController
 
     config.add_search_field 'all_fields', label: 'Everything'
     config.add_search_field 'title', label: 'Title' do |field|
-      field.solr_local_parameters = {
-        qf: '$title_qf'
+      field.solr_parameters = {
+        qf: '${title_qf}'
       }
     end
     config.add_search_field 'author', label: 'Creator / Contributor' do |field|
-      field.solr_local_parameters = {
-        qf: '$author_qf'
+      field.solr_parameters = {
+        qf: '${author_qf}'
       }
     end
 


### PR DESCRIPTION
## Why was this change made?

Local params were (effectively) disabled back in Solr 7.2 and there's no reason to use them here.

Probably fixes #914, unless there's yet more things wrong with the current configuration
