### PR TITLE
Remove field-specific configuration from the statistics dashboard query

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -8,6 +8,12 @@ class StatisticsController < Spotlight::ApplicationController
   before_action :attach_breadcrumbs
   before_action do
     authorize!(:read, current_exhibit)
+
+    blacklight_config.facet_fields.clear
+    blacklight_config.index_fields.clear
+    blacklight_config.show_fields.clear
+    blacklight_config.search_fields.clear
+    blacklight_config.sort_fields.clear
   end
 
   def show

--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -16,6 +16,11 @@ class StatisticsDashboard
       'cho_language.en_ssim',
       'cho_language.ar-Arab_ssim'
     ],
+    'f.agg_provider_country.ar-Arab_ssim.facet.limit' => -1,
+    'f.agg_provider_country.en_ssim.facet.limit' => -1,
+    'f.agg_data_provider_collection_ssim.facet.limit' => -1,
+    'f.cho_language.en_ssim.facet.limit' => -1,
+    'f.cho_language.ar-Arab_ssim.facet.limit' => -1,
     'facet.pivot': [
       %w[cho_edm_type.en_ssim cho_has_type.en_ssim].join(','),
       %w[cho_edm_type.ar-Arab_ssim cho_has_type.ar-Arab_ssim].join(','),

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe StatisticsController do
 
       # and we remove any injected query parameter data
       query = dashboard.send(:search_builder).to_h
-      expect(query.keys).not_to include(/^f\./)
+      expect(query.keys).not_to include(/^f\..*\.sort$/)
+      expect(query.keys).not_to include(/^stats\./)
     end
   end
 end

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatisticsController do
+  let(:exhibit) { create(:exhibit) }
+
+  describe 'GET show' do
+    it 'assigns @statistics_dashboard' do
+      get :show, params: { exhibit_id: exhibit.slug }
+
+      dashboard = assigns(:statistics_dashboard)
+      expect(dashboard).to be_a_kind_of StatisticsDashboard
+
+      # and we remove any injected query parameter data
+      query = dashboard.send(:search_builder).to_h
+      expect(query.keys).not_to include(/^f\./)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #928
