### PR TITLE
Keep the CatalogController search fields; fixes #944

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -12,7 +12,6 @@ class StatisticsController < Spotlight::ApplicationController
     blacklight_config.facet_fields.clear
     blacklight_config.index_fields.clear
     blacklight_config.show_fields.clear
-    blacklight_config.search_fields.clear
     blacklight_config.sort_fields.clear
   end
 

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe 'Statistics page', type: :feature do
     end
   end
 
+  # just to make sure we didn't break normal searches
+  it 'has the usual search box in the navbar' do
+    expect(page).to have_css('#search_field')
+    select('Title', from: 'Search in')
+    fill_in 'q', with: 'Book'
+    click_button 'Search'
+
+    expect(page).to have_content 'Search Results'
+  end
+
   it 'has a page available to users via a menu item in the exhibit navbar' do
     expect(page).to have_css('.exhibit-navbar li.nav-item.active', text: 'Statistics')
     expect(page).to have_css('h1', text: 'Statistics')


### PR DESCRIPTION

![Screen Shot 2020-04-15 at 14 57 23](https://user-images.githubusercontent.com/111218/79393088-72861d00-7f29-11ea-97f1-64de4c26afb7.png)
## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
