### PR TITLE
Update styling of masthead, footer, facets, etc.

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -84,7 +84,8 @@ body {
 /* Statistics page styling */
 .blacklight-statistics-show {
   .jumbotron {
-    border: 1px solid $color-gray-medium;
+    background-color: #ffffff;
+    border: 1px solid #328fc7;
     margin-top: $spacer;
 
     @media (min-width: 576px) {
@@ -94,13 +95,15 @@ body {
 }
 
 /* overrides for visual design changes */
-.btn-primary {
-  @include button-variant($color-black-light, $color-black-light);
+.btn-outline-secondary {
+  border-color: $color-blackish;
+  color: $color-blackish;
 }
 
 .nav > li > a:hover,
 .nav > li > a:focus {
-  background-color: $color-gray-medium;
+  background-color: $color-gray-light;
+  text-decoration: underline;
 }
 
 .nav-tabs > li.active > a,
@@ -119,11 +122,11 @@ body {
 }
 
 .table-striped > tbody > tr:nth-of-type(even) {
-  background-color: $color-gray-light;
+  background-color: $color-gray-lightest;
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: $color-gray-lightest;
+  background-color: #ffffff;
 }
 
 .indent-with-caret::before {
@@ -172,11 +175,11 @@ body {
   padding-left: 12px;
   padding-right: 12px;
   text-transform: uppercase;
-  color: $color-gray-medium;
+  color: $color-gray-light;
 
   &:hover,
   &:focus {
-    color: $color-gray-light;
+    color: $color-gray-lightest;
   }
 }
 

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -203,6 +203,21 @@ body {
   }
 }
 
+.facets-heading {
+  border-bottom: 1px solid $color-gray-medium;
+  width: 100%;
+}
+
+.facet-limit {
+  border: 1px solid $color-gray-medium;
+  margin-bottom: 0.5rem;
+
+  .card-header {
+    background-color: $color-gray-light;
+    border-bottom: 0;
+  }
+}
+
 .facet-limit-active {
   border-color: $color-gray-medium !important;
 
@@ -214,6 +229,18 @@ body {
 
   & > .card-header + .panel-collapse > .card-body {
     border-top-color: $color-gray-medium;
+  }
+}
+
+.constraints-container {
+  @extend .mb-4;
+}
+
+.applied-filter  {
+  background-color: $white;
+
+  .filter-name:after {
+    color: $color-black-medium;
   }
 }
 

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -73,6 +73,7 @@
 }
 
 body {
+  background-color: $body-background-color;
   margin-bottom: $footer-height + $footer-top-margin;
 
   @media (max-width: 991px) {

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -96,6 +96,7 @@ body {
 
 /* overrides for visual design changes */
 .btn-outline-secondary {
+  background-color: $white;
   border-color: $color-blackish;
   color: $color-blackish;
 }

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -1,8 +1,3 @@
-.topbar {
-  padding-bottom: .25rem;
-  padding-top: .25rem;
-}
-
 /* Curation > Analytics user activity table */
 .table.analytics {
   background-color: $color-gray-light;
@@ -12,40 +7,6 @@
     font-size: $h2-font-size;
     font-weight: 700;
     padding-bottom: 0;
-  }
-}
-
-.dlme-logo {
-  flex: 0 0 80px;
-  height: 50px;
-  margin-top: 8px;
-  margin-bottom:  8px;
-  object-fit: contain;
-
-  @include media-breakpoint-down('xs') {
-    display: none;
-  }
-
-  @include media-breakpoint-down('sm') {
-    flex: 0 0 60px;
-    margin-top: 8px;
-    margin-bottom:  8px;
-  }
-}
-
-.navbar-brand {
-  font-size: 1.25rem;
-
-  @include media-breakpoint-up('md') {
-    font-size: 1.5rem;
-  }
-
-  @include media-breakpoint-up('md') {
-    font-size: 1.75rem;
-  }
-
-  @include media-breakpoint-up('lg') {
-    font-size: 2rem;
   }
 }
 
@@ -84,7 +45,7 @@ body {
 /* Statistics page styling */
 .blacklight-statistics-show {
   .jumbotron {
-    background-color: #ffffff;
+    background-color: $white;
     border: 1px solid #328fc7;
     margin-top: $spacer;
 
@@ -127,7 +88,7 @@ body {
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #ffffff;
+  background-color: $white;
 }
 
 .indent-with-caret::before {
@@ -180,13 +141,60 @@ body {
 
   &:hover,
   &:focus {
+    background-color: rgba(255,255,255,0.2);
     color: $color-gray-lightest;
+  }
+}
+
+.image-masthead .background-container-gradient {
+  background: linear-gradient(rgba(0, 0, 0, 0.15), 75%, rgba(0, 0, 0, 0.6));
+}
+
+.dlme-logo {
+  flex: 0 0 80px;
+  height: 50px;
+  margin-right: 0.75rem;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  object-fit: contain;
+
+  @include media-breakpoint-down('xs') {
+    display: none;
+  }
+
+  @include media-breakpoint-down('sm') {
+    height: 45px;
+    margin-top: 8px;
+    margin-bottom:  8px;
+  }
+}
+
+.navbar-brand {
+  font-size: 1.25rem;
+  padding: 0;
+
+  @include media-breakpoint-up('md') {
+    font-size: 1.5rem;
+  }
+
+  @include media-breakpoint-up('md') {
+    font-size: 1.75rem;
+  }
+
+  @include media-breakpoint-up('lg') {
+    font-size: 2rem;
   }
 }
 
 .topbar {
   background-color: $topnav-background-color !important;
-  margin-bottom: 3rem;
+  margin-bottom: 4rem;
+  padding-bottom: .25rem;
+  padding-top: .5rem;
+
+  @include media-breakpoint-down('sm') {
+    margin-bottom: 0;
+  }
 }
 
 .masthead .topbar  .navbar-nav {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -34,4 +34,4 @@ $breadcrumb-divider-color: $color-black-light;
 $breadcrumb-padding-x: 0.5rem;
 
 $topnav-background-color: rgba($color-primary, 0.85);
-$navbar-active-bg: rgba($color-primary, 0.8);
+$navbar-active-bg: rgba(255, 255, 255, 0.33);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,3 +1,13 @@
+$theme-colors: (
+  "primary": #0f2450,
+  "secondary": #777,
+  "info": #328fc7,
+);
+
+$color-primary: #0f2450;
+
+$link-color: lighten($color-primary, 10%);
+
 $color-blackish: #2e2d29;
 $color-black-medium: #585754;
 $color-black-light: #777;
@@ -7,15 +17,15 @@ $color-gray-lightest: #f8f8f8;
 
 $body-background-color: #f7f7f7;
 
-$footer-background-color: #0f2450;
+$footer-background-color: $color-primary;
 $footer-height: 120px;
 $footer-top-margin: 20px;
 $footer-mobile-adjustment: 50px;
 
 $text-muted: $color-black-medium; // with gray body bg, need darker muted color
 
-$pagination-active-color: $color-blackish;
-$pagination-active-bg: $color-gray-medium;
+$pagination-active-color: $color-gray-lightest;
+$pagination-active-bg: $color-primary;
 $pagination-active-border: $color-gray-medium;
 
 $breadcrumb-bg: transparent;
@@ -23,5 +33,5 @@ $breadcrumb-active-color: $color-black-medium;
 $breadcrumb-divider-color: $color-black-light;
 $breadcrumb-padding-x: 0.5rem;
 
-$topnav-background-color: rgba(#0f2450, 0.85);
-$navbar-active-bg: rgba(#0F2450, 0.8);
+$topnav-background-color: rgba($color-primary, 0.85);
+$navbar-active-bg: rgba($color-primary, 0.8);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -5,9 +5,9 @@ $color-gray-medium: #ccc;
 $color-gray-light: #ededed;
 $color-gray-lightest: #f8f8f8;
 
-$clir-burgundy: #560319;
+$body-background-color: #f7f7f7;
 
-$footer-background-color: #434343;
+$footer-background-color: #0f2450;
 $footer-height: 120px;
 $footer-top-margin: 20px;
 $footer-mobile-adjustment: 50px;
@@ -23,5 +23,5 @@ $breadcrumb-active-color: $color-black-medium;
 $breadcrumb-divider-color: $color-black-light;
 $breadcrumb-padding-x: 0.5rem;
 
-$topnav-background-color: rgba(#0f2450, 0.75);
-$navbar-active-bg: rgba(#0F2450, 0.75);
+$topnav-background-color: rgba(#0f2450, 0.85);
+$navbar-active-bg: rgba(#0F2450, 0.8);

--- a/app/views/shared/_header_navbar_masthead.html.erb
+++ b/app/views/shared/_header_navbar_masthead.html.erb
@@ -1,3 +1,4 @@
+<span class="background-container-gradient"></span>
 <nav class="navbar navbar-expand-md navbar-dark topbar" role="navigation" aria-label="<%= t('spotlight.topbar.label') %>">
   <div class="<%= container_classes %>">
     <div class="navbar-brand">


### PR DESCRIPTION
General styling updates to get the site looking a little better and coordinate with the recent masthead update. There will be more fine-tuning to do later, but I'd like to get the font updates done next and return to make any further styling updates after we're happy with font sizing, etc.

### Examples with changes from this PR

<img width="1015" alt="Screen Shot 2020-04-15 at 2 55 11 PM" src="https://user-images.githubusercontent.com/101482/79393186-a7926f80-7f29-11ea-8b2f-537a90ed2a42.png">

---

<img width="1015" alt="Screen Shot 2020-04-15 at 2 54 50 PM" src="https://user-images.githubusercontent.com/101482/79393211-b7aa4f00-7f29-11ea-9242-6dc040f5ac3a.png">

---

<img width="1010" alt="Screen Shot 2020-04-15 at 3 01 05 PM" src="https://user-images.githubusercontent.com/101482/79393328-f809cd00-7f29-11ea-99b6-686c6ee767ee.png">

