### PR TITLE
Don't do anything to the breadcrumb divider in RTL mode

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -44,10 +44,6 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     text-align: left;
   }
 
-  .breadcrumb-item + .breadcrumb-item::before {
-    content: "\\";
-  }
-
   /** Fix margins for the inline list (used in the footer) */
   .list-inline-item {
     &:last-child {


### PR DESCRIPTION
Fixes #955

## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
