### PR TITLE
Remove border and explicit width on About page iframe

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -25,6 +25,11 @@ h2, .h2 {
   color: $color-black-light;
 }
 
+.blacklight-about_pages-show iframe {
+  border: 0;
+  width: 100%;
+}
+
 /* Curation > Analytics user activity table */
 .table.analytics {
   background-color: $color-gray-light;


### PR DESCRIPTION
Closes #880.

This is for the email announcements signup form that is hosted by CLIR that we display on an About page. @waynegraham made some styling updates to the form itself and this PR includes a couple more on the `<iframe>` element to remove the border and change the width from an explicit setting to `100%`. I think these changes make the embedded form work pretty well in the about page context, at any browser width.


<img width="975" alt="Screen Shot 2020-04-20 at 1 48 26 PM" src="https://user-images.githubusercontent.com/101482/79798977-9f15ac80-830e-11ea-9a21-af355d32b698.png">


Note that my SCSS selector here will match any iframe we add to a DLME about page. I don't think that's a problem since we probably don't want a border or explicit width on any other iframe we might add to an about page, but if we end up wanting to make this more targeted it should be easy to do by using an attribute selector that references the URL of the form we're bringing in.
