### PR TITLE
Update theme colors for Mirador viewer

### DIFF
--- a/app/javascript/packs/mirador.js
+++ b/app/javascript/packs/mirador.js
@@ -25,6 +25,16 @@ const manifestUrl = document.querySelector('#m3').dataset.iiifManifest;
 
 Mirador.viewer({
   id: 'm3',
+  theme: {
+    palette: {
+      primary: {
+        main: '#17377b'
+      },
+      shades: {
+        dark: '#dadada'
+      }
+    }
+  },
   window: {
     allowClose: false,
     allowFullscreen: true,


### PR DESCRIPTION
Closes #637.

This PR updates a couple of the Mirador theme colors:

- canvas background - to be a bit darker than the default, which blends into the site background a bit too much
- primary color -  to match the link color we're using generally on the site; shows up as the blue top border, selected icon color, and link color within the viewer

<img width="979" alt="Screen Shot 2020-04-20 at 2 57 51 PM" src="https://user-images.githubusercontent.com/101482/79803844-a68d8380-8317-11ea-8d0b-e3490e3b2ba9.png">

Everything else seems configured how we want it for DLME, unless I'm missing something.

One exception might be the Download & Share plugin. I assume it doesn't make sense to display that because of the way we're bringing in the IIIF items, but if whomever reviews this PR knows differently let me know.
