### PR TITLE
Adjust hover styling on sidebar links

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -97,7 +97,6 @@ body {
 
 .nav > li > a:hover,
 .nav > li > a:focus {
-  background-color: $color-gray-light;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Why was this change made?

Links in the sidebar (About pages, Admin dashboard pages) get both underline and a background color on hover. They only need one indicator that they are being hovered/focused, so I removed the background color.

I don't think this change affects links in other contexts, which don't seem to have the double indicator issue.

### Before
<img width="258" alt="Screen Shot 2020-04-20 at 3 37 23 PM" src="https://user-images.githubusercontent.com/101482/79806530-7a750100-831d-11ea-9056-c6e1674dccc4.png">

### After
<img width="258" alt="Screen Shot 2020-04-20 at 3 37 45 PM" src="https://user-images.githubusercontent.com/101482/79806545-81037880-831d-11ea-8310-8601c63d0f07.png">

