### PR TITLE
Reduce indent of nested hierarchical facet values

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -30,6 +30,16 @@ h2, .h2 {
   width: 100%;
 }
 
+.facet-hierarchy {
+  .facet_select {
+    max-width: calc(100% - 3em);
+  }
+
+  .h-leaf {
+    padding-left: 0;
+  }
+}
+
 /* Curation > Analytics user activity table */
 .table.analytics {
   background-color: $color-gray-light;

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -117,7 +117,7 @@ $breadcrumb-item-padding-x: 0.5rem !default;
 
     .h-leaf {
       padding-left: 0;
-      padding-right: 1.3em;
+      padding-right: 0;
     }
 
     .facet-count {


### PR DESCRIPTION
Closes #966.

- Reduces indentation of second-level values
- Increases width values can take

Together these reduce the frequency of having Type facet values that wrap oddly.

These examples are the worst case (narrowest) viewport width:

<img width="314" alt="Screen Shot 2020-04-22 at 2 44 31 PM" src="https://user-images.githubusercontent.com/101482/80037202-01ee7b80-84a8-11ea-97b3-323e5053f5df.png">



---

<img width="314" alt="Screen Shot 2020-04-22 at 2 38 06 PM" src="https://user-images.githubusercontent.com/101482/80036849-65c47480-84a7-11ea-80f4-e11d1e445d38.png">
