### PR TITLE
Adjust background of stats summary boxes

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -78,7 +78,7 @@ body {
 /* Statistics page styling */
 .blacklight-statistics-show {
   .jumbotron {
-    background-color: $white;
+    background: linear-gradient(0.35turn, $color-gray-light, 65%, $white);
     border: 1px solid $color-primary;
     margin-top: $spacer;
 


### PR DESCRIPTION
## Why was this change made?
The white background of the summary boxes felt a bit too stark to me. 

With this PR they now look like below, which still doesn't feel great but maybe a slight improvement until I think of something better...

<img width="1017" alt="Screen Shot 2020-04-22 at 2 51 35 PM" src="https://user-images.githubusercontent.com/101482/80037710-fbaccf00-84a8-11ea-9de4-ad17a38bada3.png">

