### PR TITLE
Make some RtL adjustments to masthead elements

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -135,4 +135,20 @@ $breadcrumb-item-padding-x: 0.5rem !default;
       unicode-bidi: plaintext;
     }
   }
+
+  .dlme-logo {
+    margin-left: 0.75rem;
+    margin-right: 0;
+  }
+
+  .image-masthead {
+    .navbar-nav  {
+      padding-right: 0;
+    }
+
+    .nav-item + .nav-item,
+    .navbar-brand {
+      margin-right: 0;
+    }
+  }
 }


### PR DESCRIPTION
There were some adjustments needed in RtL mode to get more desirable alignment of site logo and main menu elements.

### Before
<img width="762" alt="Screen Shot 2020-04-24 at 10 28 39 AM" src="https://user-images.githubusercontent.com/101482/80240508-ca521180-8616-11ea-9b6d-8dd426cbdce6.png">


### After
<img width="762" alt="Screen Shot 2020-04-24 at 10 28 01 AM" src="https://user-images.githubusercontent.com/101482/80240499-c6be8a80-8616-11ea-92e7-20516cb5dac1.png">

