### PR TITLE
About page heading spacing

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -318,6 +318,10 @@ body {
   }
 }
 
+.page-sidebar .contacts-header {
+  padding-bottom: 0.5rem;
+}
+
 // Overrides for mobile viewports
 @media (max-width: 767px) {
   .navbar-default .navbar-form {

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -136,6 +136,11 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     }
   }
 
+  #sidebar .contact-properties {
+    padding-left: 0;
+    padding-right: 1rem;
+  }
+
   .dlme-logo {
     margin-left: 0.75rem;
     margin-right: 0;


### PR DESCRIPTION
Closes #987.

### Problems
- Not enough vertical spacing in section heading when in Arabic
- Section items indented too far to the right

<img width="325" alt="Screen Shot 2020-05-19 at 3 48 08 PM" src="https://user-images.githubusercontent.com/101482/82386122-989b5300-99e8-11ea-8326-9a7d60cbdc11.png">

### Fixes
<img width="325" alt="Screen Shot 2020-05-19 at 3 47 07 PM" src="https://user-images.githubusercontent.com/101482/82386179-a3ee7e80-99e8-11ea-8777-5c28189d22b4.png">

