### PR TITLE
Add BIDI markup for statistics page data

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -8,6 +8,7 @@ $breadcrumb-item-padding-x: 0.5rem !default;
 .document-metadata dd,
 .browse-category-title,
 .blacklight-browse-show h1 .title,
+.blacklight-statistics-show .value,
 .index_title a {
   unicode-bidi: plaintext;
 }

--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <% contributors.institutions.each do |institution| %>
       <tr>
-        <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name) %></td>
-        <td><%= institution.countries.join(', ') %></td>
+        <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name), class: 'value' %></td>
+        <td class="value"><%= institution.countries.join(', ') %></td>
         <td class="text-right"><%= number_with_delimiter(institution.collection_count) %></td>
         <td class="text-right"><%= number_with_delimiter(institution.item_count) %></td>
       </tr>

--- a/app/views/statistics/_items.html.erb
+++ b/app/views/statistics/_items.html.erb
@@ -12,7 +12,7 @@
         <% items.by_type.each do |field| %>
           <tr>
             <td>
-              <%= link_to path_for_facet(items.type_facet, field['value']) do %>
+              <%= link_to path_for_facet(items.type_facet, field['value']), class: 'value' do %>
                 <%= facet_display_value(items.type_facet, field['value']) %>
               <% end %>
             </td>
@@ -21,7 +21,7 @@
           <% field['pivot'].each do |pivot| %>
             <tr>
               <td class="pl-4 indent-with-caret">
-                <%= link_to path_for_facet(items.type_facet, [field['value'], pivot['value']].join(':')) do %>
+                <%= link_to path_for_facet(items.type_facet, [field['value'], pivot['value']].join(':')), class: 'value' do %>
                   <%= facet_display_value(items.type_facet, pivot['value']) %>
                 <% end %>
               </td>
@@ -44,7 +44,7 @@
         <% items.by_language.each do |field| %>
           <tr>
             <td>
-              <%= link_to path_for_facet(items.language_field, field['value']) do %>
+              <%= link_to path_for_facet(items.language_field, field['value']), class: 'value' do %>
                 <%= facet_display_value(items.language_field, field['value']) %>
               <% end %>
             </td>


### PR DESCRIPTION
This brings the statistics page inline with metadata display practices elsewhere in the app.