### PR TITLE
Use agg_data_provider_country for item provider stats

### DIFF
--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -12,12 +12,16 @@ class StatisticsDashboard
     'facet.field': [
       'agg_provider_country.ar-Arab_ssim',
       'agg_provider_country.en_ssim',
+      'agg_provider_data_country.ar-Arab_ssim',
+      'agg_provider_data_country.en_ssim',
       'agg_data_provider_collection_ssim',
       'cho_language.en_ssim',
       'cho_language.ar-Arab_ssim'
     ],
     'f.agg_provider_country.ar-Arab_ssim.facet.limit' => -1,
     'f.agg_provider_country.en_ssim.facet.limit' => -1,
+    'f.agg_data_provider_country.ar-Arab_ssim.facet.limit' => -1,
+    'f.agg_data_provider_country.en_ssim.facet.limit' => -1,
     'f.agg_data_provider_collection_ssim.facet.limit' => -1,
     'f.cho_language.en_ssim.facet.limit' => -1,
     'f.cho_language.ar-Arab_ssim.facet.limit' => -1,
@@ -26,8 +30,8 @@ class StatisticsDashboard
       %w[cho_edm_type.ar-Arab_ssim cho_has_type.ar-Arab_ssim].join(','),
       %w[agg_provider.en_ssim agg_provider_country.en_ssim agg_data_provider_collection_ssim].join(','),
       %w[agg_provider.ar-Arab_ssim agg_provider_country.ar-Arab_ssim agg_data_provider_collection_ssim].join(','),
-      %w[agg_data_provider.en_ssim agg_provider_country.en_ssim agg_data_provider_collection_ssim].join(','),
-      %w[agg_data_provider.ar-Arab_ssim agg_provider_country.ar-Arab_ssim agg_data_provider_collection_ssim].join(',')
+      %w[agg_data_provider.en_ssim agg_data_provider_country.en_ssim agg_data_provider_collection_ssim].join(','),
+      %w[agg_data_provider.ar-Arab_ssim agg_data_provider_country.ar-Arab_ssim agg_data_provider_collection_ssim].join(',')
     ]
   }.freeze
 
@@ -227,7 +231,7 @@ class StatisticsDashboard
     private
 
     def countries_field
-      StatisticsDashboard.locale_aware_field('agg_provider_country')
+      StatisticsDashboard.locale_aware_field("#{provider_field_key}_country")
     end
 
     def collections_field

--- a/spec/features/statistics_spec.rb
+++ b/spec/features/statistics_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe 'Statistics page', type: :feature do
           'agg_data_provider_collection_ssim' => ['Value 1', '500', 'Value 2', '300']
         },
         'facet_pivot' => {
-          'agg_data_provider.en_ssim,agg_provider_country.en_ssim,agg_data_provider_collection_ssim' => [
+          'agg_data_provider.en_ssim,agg_data_provider_country.en_ssim,agg_data_provider_collection_ssim' => [
             { 'value' => 'Institution 1', 'count' => '500', 'pivot' => [
               { 'value' => 'Country 1', 'count' => '500' }
             ] },
             { 'value' => 'Institution 2', 'count' => '300', 'pivot' => [
-              { 'value' => 'Country 2', 'count' => '300' }
+              { 'value' => 'Country 2', 'count' => '200' },
+              { 'value' => 'Country 3', 'count' => '100' }
             ] }
           ],
           'agg_provider.en_ssim,agg_provider_country.en_ssim,agg_data_provider_collection_ssim' => [
@@ -80,7 +81,7 @@ RSpec.describe 'Statistics page', type: :feature do
 
   it 'has a Item Contributors section' do
     expect(page).to have_css('.jumbotron h2', text: '2 item contributors')
-    expect(page).to have_css('.jumbotron p', text: '2 countries')
+    expect(page).to have_css('.jumbotron p', text: '3 countries')
     expect(page).to have_css('h2', text: 'Item Contributors · 2')
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes part of #1003 by using the agg_data_provider_country field for data providers 

## Was the documentation (README, API, wiki, ...) updated?
