### PR TITLE
Close the link in the contextual_result_info note.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
     show_with_viewer:
       view_on_contributor_website: View on contributor website
   contextual_result_info:
-    body_html: You might see more results for your query by <a href='%{link}'>entering your search terms in another language<a>.
+    body_html: You might see more results for your query by <a href='%{link}'>entering your search terms in another language</a>.
     disable_session: Don't show again
     dismiss: Dismiss
   date:


### PR DESCRIPTION
## Why was this change made?
Closes #1083 

To fix the HTML so the anchor tag was properly closed.

## Before
<img width="928" alt="Screen Shot 2020-11-13 at 4 36 26 PM" src="https://user-images.githubusercontent.com/101482/99130785-892f4800-25ce-11eb-84fb-00229b816252.png">


## After
<img width="856" alt="Screen Shot 2021-01-11 at 3 27 05 PM" src="https://user-images.githubusercontent.com/96776/104250061-9e372480-5421-11eb-8412-4867dd0ebfaf.png">


## Was the documentation (README, API, wiki, ...) updated?
