### PR TITLE
Update the per-page config to be divisible by 3

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,9 +36,14 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: 'search',
-      rows: 10,
+      rows: 12,
       fl: '*'
     }
+
+    # Maximum number of results to show per page
+    config.max_per_page = 96
+    # Options for the user for number of results to show per page
+    config.per_page = [12, 24, 48, 96]
 
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'

--- a/db/migrate/20210112001854_change_per_page.rb
+++ b/db/migrate/20210112001854_change_per_page.rb
@@ -1,0 +1,20 @@
+class ChangePerPage < ActiveRecord::Migration[5.2]
+  def change
+    Spotlight::Exhibit.find_each do |exhibit|
+      config = exhibit.blacklight_configuration
+      case config.default_per_page
+      when 10
+        config.default_per_page = 12
+      when 20
+        config.default_per_page = 24
+      when 50
+        config.default_per_page = 48
+      when 100
+        config.default_per_page = 96
+      else
+        config.default_per_page = 12
+      end
+      config.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_07_144323) do
+ActiveRecord::Schema.define(version: 2021_01_12_001854) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
Part of sul-dlss/exhibits#1942

## Why was this change made?
Blank spaces at the end of gallery results are problematic, this makes sure that the number of results returned will always fill the page.

<img width="965" alt="Screen Shot 2021-01-11 at 4 26 44 PM" src="https://user-images.githubusercontent.com/96776/104253686-f4a86100-5429-11eb-9402-3647605cd3cb.png">


## Was the documentation (README, API, wiki, ...) updated?
