### PR TITLE
Fixes #1074, by proxying http only images and disabling http iiif content

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -56,6 +56,9 @@ class CatalogController < ApplicationController
       **multilingual_locale_aware_field('cho_title')
     )
 
+    config.index.document_presenter_class = DlmeIndexPresenter
+    config.show.document_presenter_class = DlmeShowPresenter
+
     config.index.thumbnail_field = 'agg_preview.wr_id_ssim'
     config.index.default_thumbnail = 'default.png'
 

--- a/app/controllers/image_proxy_controller.rb
+++ b/app/controllers/image_proxy_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+##
+# Controller for proxying HTTP images
+class ImageProxyController < ApplicationController
+  before_action :validate_token
+
+  def access
+    send_data proxied_response.body, type: proxied_response.content_type, disposition: 'inline'
+  end
+
+  private
+
+  ##
+  # To prevent outside applications from using this proxy
+  def validate_token
+    render plain: 'invalid token', status: :forbidden unless valid_authenticity_token?(session, image_token)
+  end
+
+  def proxied_response
+    @proxied_response ||= begin
+      benchmark "Fetch #{image_url}" do
+        HTTP.get(image_url)
+      end
+    end
+  end
+
+  def image_url
+    params.require(:url)
+  end
+
+  def image_token
+    params.require(:token)
+  end
+end

--- a/app/controllers/image_proxy_controller.rb
+++ b/app/controllers/image_proxy_controller.rb
@@ -3,7 +3,7 @@
 ##
 # Controller for proxying HTTP images
 class ImageProxyController < ApplicationController
-  before_action :validate_token
+  before_action :validate_referer
 
   CacheableResponse = Struct.new(:body, :type)
 
@@ -15,8 +15,8 @@ class ImageProxyController < ApplicationController
 
   ##
   # To prevent outside applications from using this proxy
-  def validate_token
-    render plain: 'invalid token', status: :forbidden unless valid_authenticity_token?(session, image_token)
+  def validate_referer
+    render plain: 'invalid referrer', status: :forbidden unless request.referer.to_s.starts_with?(root_url)
   end
 
   def proxied_response
@@ -32,9 +32,5 @@ class ImageProxyController < ApplicationController
 
   def image_url
     params.require(:url)
-  end
-
-  def image_token
-    params.require(:token)
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -36,7 +36,7 @@ class SolrDocument
   end
 
   def iiifable?
-    iiif_manifest_url.present?
+    iiif_manifest_url.present? && iiif_manifest_url.starts_with?('https://')
   end
 
   def iiif_manifest_url

--- a/app/presenters/dlme_index_presenter.rb
+++ b/app/presenters/dlme_index_presenter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+##
+# Custom DLME Index Presenter
+class DlmeIndexPresenter < Blacklight::IndexPresenter
+  self.thumbnail_presenter = DlmeThumbnailPresenter
+end

--- a/app/presenters/dlme_show_presenter.rb
+++ b/app/presenters/dlme_show_presenter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+##
+# Custom DLME Show Presenter
+class DlmeShowPresenter < Blacklight::ShowPresenter
+  self.thumbnail_presenter = DlmeThumbnailPresenter
+end

--- a/app/presenters/dlme_thumbnail_presenter.rb
+++ b/app/presenters/dlme_thumbnail_presenter.rb
@@ -3,8 +3,16 @@
 ##
 # Custom DLME Thumbnail Presenter
 class DlmeThumbnailPresenter < Blacklight::ThumbnailPresenter
+  ##
+  # Overridden to support lazy options
+  def thumbnail_tag(image_options = {}, url_options = {})
+    super(image_options.merge(loading: 'lazy'), url_options)
+  end
+
   private
 
+  ##
+  # Overridden to support http proxy
   def thumbnail_value_from_document
     url = super
     return view_context.image_proxy_path(url: url, token: view_context.form_authenticity_token) if url.to_s.start_with?('http://')

--- a/app/presenters/dlme_thumbnail_presenter.rb
+++ b/app/presenters/dlme_thumbnail_presenter.rb
@@ -15,7 +15,7 @@ class DlmeThumbnailPresenter < Blacklight::ThumbnailPresenter
   # Overridden to support http proxy
   def thumbnail_value_from_document
     url = super
-    return view_context.image_proxy_path(url: url, token: view_context.form_authenticity_token) if url.to_s.start_with?('http://')
+    return view_context.image_proxy_path(url: url) if url.to_s.start_with?('http://')
 
     url
   end

--- a/app/presenters/dlme_thumbnail_presenter.rb
+++ b/app/presenters/dlme_thumbnail_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+##
+# Custom DLME Thumbnail Presenter
+class DlmeThumbnailPresenter < Blacklight::ThumbnailPresenter
+  private
+
+  def thumbnail_value_from_document
+    url = super
+    return view_context.image_proxy_path(url: url, token: view_context.form_authenticity_token) if url.to_s.start_with?('http://')
+
+    url
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'image_proxy' => 'image_proxy#access', as: 'image_proxy'
+
   Blacklight::Engine.routes.default_scope = { path: "(:locale)", locale: Regexp.union(Spotlight::Engine.config.i18n_locales.keys.map(&:to_s)), module: 'blacklight' }
   mount Blacklight::Engine => '/'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,8 @@ analytics:
   pkcs12_key_path: ~
   email: ~
 
+cache_period: <%= 12.hours %>
+
 contact:
   email: ~
 

--- a/spec/controllers/image_proxy_controller_spec.rb
+++ b/spec/controllers/image_proxy_controller_spec.rb
@@ -6,18 +6,24 @@ RSpec.describe ImageProxyController do
   describe 'GET access' do
     let(:image_response) { instance_double('HTTP::Response', body: '', content_type: 'image/jpeg') }
 
+    # rubocop:disable RSpec/BeforeAfterAll
+    before(:all) do
+      Rails.cache.clear
+    end
+    # rubocop:enable RSpec/BeforeAfterAll
+
     it 'proxies an image request' do
       allow(controller).to receive(:valid_authenticity_token?).and_return true
       # rubocop:disable RSpec/MessageSpies
       expect(HTTP).to receive(:get).with('http://example.com/image1.jpg').and_return(image_response)
       # rubocop:enable RSpec/MessageSpies
-      get :access, params: { url: 'http://example.com/image1.jpg', token: 'valid' }
+      request.headers['Referer'] = controller.search_catalog_url
+      get :access, params: { url: 'http://example.com/image1.jpg' }
       expect(response).to have_http_status(:ok)
     end
 
-    it 'without a valid token is forbidden' do
-      allow(controller).to receive(:valid_authenticity_token?).and_return false
-      get :access, params: { url: 'http://example.com/image1.jpg', token: 'invalid' }
+    it 'without a valid referer is forbidden' do
+      get :access, params: { url: 'http://example.com/image1.jpg' }
       expect(response).to have_http_status(:forbidden)
     end
   end

--- a/spec/controllers/image_proxy_controller_spec.rb
+++ b/spec/controllers/image_proxy_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImageProxyController do
+  describe 'GET access' do
+    let(:image_response) { instance_double('HTTP::Response', body: '', content_type: 'image/jpeg') }
+
+    it 'proxies an image request' do
+      allow(controller).to receive(:valid_authenticity_token?).and_return true
+      # rubocop:disable RSpec/MessageSpies
+      expect(HTTP).to receive(:get).with('http://example.com/image1.jpg').and_return(image_response)
+      # rubocop:enable RSpec/MessageSpies
+      get :access, params: { url: 'http://example.com/image1.jpg', token: 'valid' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'without a valid token is forbidden' do
+      allow(controller).to receive(:valid_authenticity_token?).and_return false
+      get :access, params: { url: 'http://example.com/image1.jpg', token: 'invalid' }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -87,6 +87,32 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe '#iiifable?' do
+    context 'known IIIF provider' do
+      let(:source) do
+        {
+          'agg_is_shown_at.wr_is_referenced_by_ssi' => ['https://iiif.bodleian.ox.ac.uk/iiif/manifest/22974622-d838-4496-8835-33ecda85f21f.json']
+        }
+      end
+
+      it do
+        expect(document.iiifable?).to be true
+      end
+    end
+
+    context 'http:// IIIF provider' do
+      let(:source) do
+        {
+          'agg_is_shown_at.wr_is_referenced_by_ssi' => ['http://iiif.bodleian.ox.ac.uk/iiif/manifest/22974622-d838-4496-8835-33ecda85f21f.json']
+        }
+      end
+
+      it do
+        expect(document.iiifable?).to be false
+      end
+    end
+  end
+
   describe '#iiif_manifest_url' do
     context 'known IIIF provider' do
       let(:source) do

--- a/spec/presenters/dlme_thumbnail_presenter_spec.rb
+++ b/spec/presenters/dlme_thumbnail_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DlmeThumbnailPresenter do
   end
   let(:document) { SolrDocument.new('xyz' => 'https://www.example.com/image.png') }
   let(:view_context) do
-    instance_double('ActionView::ViewContext', form_authenticity_token: 'yolo')
+    instance_double('ActionView::ViewContext')
   end
   let(:presenter) { described_class.new(document, view_context, config) }
 
@@ -34,7 +34,7 @@ RSpec.describe DlmeThumbnailPresenter do
       it 'returns proxy value' do
         # rubocop:disable RSpec/MessageSpies
         expect(view_context).to receive(:image_proxy_path)
-          .with(url: 'http://www.example.com/image.png', token: 'yolo')
+          .with(url: 'http://www.example.com/image.png')
           .and_return('/image_proxy')
         # rubocop:enable RSpec/MessageSpies
         expect(presenter.send(:thumbnail_value_from_document)).to eq '/image_proxy'

--- a/spec/presenters/dlme_thumbnail_presenter_spec.rb
+++ b/spec/presenters/dlme_thumbnail_presenter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DlmeThumbnailPresenter do
+  let(:config) do
+    Blacklight::OpenStructWithHashAccess.new(thumbnail_field: :xyz)
+  end
+  let(:document) { SolrDocument.new('xyz' => 'https://www.example.com/image.png') }
+  let(:view_context) do
+    instance_double('ActionView::ViewContext', form_authenticity_token: 'yolo')
+  end
+  let(:presenter) { described_class.new(document, view_context, config) }
+
+  describe '#thumbnail_value_from_document' do
+    context 'when not http://' do
+      it 'returns super value' do
+        expect(presenter.send(:thumbnail_value_from_document)).to eq 'https://www.example.com/image.png'
+      end
+    end
+
+    context 'when http://' do
+      let(:document) { SolrDocument.new('xyz' => 'http://www.example.com/image.png') }
+
+      it 'returns proxy value' do
+        # rubocop:disable RSpec/MessageSpies
+        expect(view_context).to receive(:image_proxy_path)
+          .with(url: 'http://www.example.com/image.png', token: 'yolo')
+          .and_return('/image_proxy')
+        # rubocop:enable RSpec/MessageSpies
+        expect(presenter.send(:thumbnail_value_from_document)).to eq '/image_proxy'
+      end
+    end
+  end
+end

--- a/spec/presenters/dlme_thumbnail_presenter_spec.rb
+++ b/spec/presenters/dlme_thumbnail_presenter_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe DlmeThumbnailPresenter do
   end
   let(:presenter) { described_class.new(document, view_context, config) }
 
+  describe '#thumbnail_tag' do
+    it 'merges in lazy attribute' do
+      # rubocop:disable RSpec/MessageSpies
+      expect(view_context).to receive(:image_tag).with('https://www.example.com/image.png', { loading: 'lazy' })
+      # rubocop:enable RSpec/MessageSpies
+      presenter.thumbnail_tag
+    end
+  end
+
   describe '#thumbnail_value_from_document' do
     context 'when not http://' do
       it 'returns super value' do

--- a/spec/views/catalog/_show_with_viewer.html.erb_spec.rb
+++ b/spec/views/catalog/_show_with_viewer.html.erb_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'catalog/_show_with_viewer.html.erb', type: :view do
 
     it 'renders a thumbnail that links to the source' do
       expect(rendered).to have_link href: 'http://example.com/resource/'
-      expect(rendered).to have_selector 'a img[@src^="/image_proxy?token"]'
+      expect(rendered).to have_selector 'a img[@src^="/image_proxy?url"]'
       expect(rendered).to have_text 'View on contributor website'
     end
   end

--- a/spec/views/catalog/_show_with_viewer.html.erb_spec.rb
+++ b/spec/views/catalog/_show_with_viewer.html.erb_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'catalog/_show_with_viewer.html.erb', type: :view do
 
     it 'renders a thumbnail that links to the source' do
       expect(rendered).to have_link href: 'http://example.com/resource/'
-      expect(rendered).to have_selector 'a img[@src="http://example.com/resource.jpg"]'
+      expect(rendered).to have_selector 'a img[@src^="/image_proxy?token"]'
       expect(rendered).to have_text 'View on contributor website'
     end
   end


### PR DESCRIPTION
## Why was this change made?
Fixes #1074

This adds a protected proxy for http images and disables http iiif content which we cannot view.

An additional thing added was the `loading="lazy"` attribute for images so we don't try and proxy non-visible images.

## Was the documentation (README, API, wiki, ...) updated?
