### PR TITLE
A follow on to #1101 fixing the docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker:
-        version: 19.0.13
+        version: 19.03.13
     - run:
         name: Build Docker image
         command: |
@@ -141,7 +141,7 @@ jobs:
     - attach_workspace:
         at: /tmp/workspace
     - setup_remote_docker:
-        version: 19.0.13
+        version: 19.03.13
     - run:
         name: Load archived Docker image
         command: |
@@ -161,7 +161,7 @@ jobs:
     - attach_workspace:
         at: /tmp/workspace
     - setup_remote_docker:
-        version: 19.0.13
+        version: 19.03.13
     - run:
         name: Load archived Docker image
         command: |


### PR DESCRIPTION
Available versions here: https://circleci.com/docs/2.0/building-docker-images/#docker-version

This fixes a typo

![](https://media.giphy.com/media/1YlqzxnnQwaGc/giphy.gif)