### PR TITLE
Update multilingual metadata display

### DIFF
--- a/app/controllers/concerns/multilingual_locale_aware_field.rb
+++ b/app/controllers/concerns/multilingual_locale_aware_field.rb
@@ -4,8 +4,8 @@
 module MultilingualLocaleAwareField
   def lang_config
     @lang_config ||= {
-      'ar' => [%w[ar-Arab ar-Latn], default: (%w[en none] + Settings.acceptable_bcp47_codes).uniq],
-      'en' => ['en', default: (%w[ar-Arab ar-Latn none] + Settings.acceptable_bcp47_codes).uniq]
+      'ar' => ['ar-Arab', default: (sorted_locales(Settings.acceptable_bcp47_codes, '-Arab') + %w[none]).uniq],
+      'en' => ['en', default: (sorted_locales(Settings.acceptable_bcp47_codes, '-Latn') + %w[none]).uniq]
     }.with_indifferent_access
   end
 
@@ -39,5 +39,17 @@ module MultilingualLocaleAwareField
         end
       end
     }
+  end
+
+  private
+
+  def sorted_locales(locales, sort_by)
+    locales.sort_by.with_index do |locale, index|
+      if locale.include?(sort_by)
+        index - locales.length
+      else
+        index
+      end
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,12 +38,17 @@ acceptable_bcp47_codes:
   - en
   - ar-Arab
   - ar-Latn
+  - es
   - fa-Arab
   - fa-Latn
   - fr
   - he
-  - ms
+  - ms-Arab
+  - ms-Latn
+  - syc
   - tr-Arab
   - tr-Latn
+  - und-Arab
+  - und-Latn
   - ur-Arab
   - ur-Latn

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,10 +32,12 @@ feature_flags:
 
 searching_site_slug: 'searching-this-site'
 
+# en is placed first in this list so that when the codes are sorted en will be the
+# first to come after the codes sorted to the beginning (e.g. *-Arab or *-Latn)
 acceptable_bcp47_codes:
+  - en
   - ar-Arab
   - ar-Latn
-  - en
   - fa-Arab
   - fa-Latn
   - fr

--- a/spec/controllers/concerns/multilingual_locale_aware_field_spec.rb
+++ b/spec/controllers/concerns/multilingual_locale_aware_field_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MultilingualLocaleAwareField do
+  let(:stub_class) do
+    Class.new do
+      include MultilingualLocaleAwareField
+    end
+  end
+
+  describe '#lang_config' do
+    let(:lang_config) { stub_class.new.lang_config }
+
+    it 'sorts the relevant locales first in the default fallback language codes' do
+      ar_default = lang_config['ar'].last['default']
+      en_default = lang_config['en'].last['default']
+
+      expect(ar_default.take(4)).to all(match(/-Arab/))
+      expect(en_default.take(4)).to all(match(/-Latn/))
+    end
+
+    # If this test fails its likely because "en" is not first in acceptable_bcp47_codes
+    it 'returns "en" after the sorted language codes' do
+      first_non_arab_langauge = lang_config['ar'].last['default'].find { |lang| !lang.end_with?('-Arab') }
+      expect(first_non_arab_langauge).to eq 'en'
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
In order to update the order of multilingual metadata fields displayed around the application.

Closes #1052 

## Was the documentation (README, API, wiki, ...) updated?
N/A

Below is a list of the before/after states of what language tagged fields we attempt to display when the application's UI  has been set to a particular language.

## Language order for Arabic (BEFORE)

Default display

  <pre>"ar-Arab"
"ar-Latn"</pre>

<details>
  <summary>Fallback display</summary>

<pre> "en"
 "none"
 "ar-Arab"
 "ar-Latn"
 "fa-Arab"
 "fa-Latn"
 "fr"
 "he"
 "ms"
 "tr-Arab"
 "tr-Latn"
 "ur-Arab"
 "ur-Latn"</pre>
</details>


## Language order for English (BEFORE)

Default display
<pre>"en"</pre>

<details>
  <summary>Fallback display</summary>
  <pre> "ar-Arab"
 "ar-Latn"
 "none"
 "en"
 "fa-Arab"
 "fa-Latn"
 "fr"
 "he"
 "ms"
 "tr-Arab"
 "tr-Latn"
 "ur-Arab"
 "ur-Latn"</pre>
</details>

## Language order for Arabic (AFTER)

Default display
<pre>"ar-Arab"</pre>


<details>
  <summary>Fallback display</summary>
  <pre> "ar-Arab"
 "fa-Arab"
 "ms-Arab"
 "tr-Arab"
 "und-Arab"
 "ur-Arab"
 "en"
 "ar-Latn"
 "es"
 "fa-Latn"
 "fr"
 "he"
 "ms-Latn"
 "syc"
 "tr-Latn"
 "und-Latn"
 "ur-Latn"
 "none"</pre>
</details>

## Language order for English (AFTER)
Default display
<pre>"en"</pre>

<details>
  <summary>Fallback display</summary>
  <pre> "ar-Latn"
 "fa-Latn"
 "ms-Latn"
 "tr-Latn"
 "und-Latn"
 "ur-Latn"
 "en"
 "ar-Arab"
 "es"
 "fa-Arab"
 "fr"
 "he"
 "ms-Arab"
 "syc"
 "tr-Arab"
 "und-Arab"
 "ur-Arab"
 "none"</pre>
</details>