### PR TITLE
Explicitly add HTTP gem dependency (only in dev, test currently)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem 'devise-guests', '~> 0.6'
 gem 'dry-validation'
 
 gem 'honeybadger'
+gem 'http'
 gem 'lograge'
 gem 'okcomputer'
 gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,6 +654,7 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id
   honeybadger
+  http
   i18n-js
   i18n-tasks
   iiif-presentation (~> 0.2.0)


### PR DESCRIPTION
## Why was this change made?
This was causing an issue in production https://app.honeybadger.io/projects/53082/faults/73653608

Related to #1074

## Was the documentation (README, API, wiki, ...) updated?
