### PR TITLE
Tweak solr for improved relevancy and user experience

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
         CC_TEST_REPORTER_ID: 0603d31c367f7e726e4db6e249d4b62025c768000d43b02259a65e8486812362
-    - image: solr:8
+    - image: solr:7
       command: bin/solr -cloud -noprompt -f -p 8983
     steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
         CC_TEST_REPORTER_ID: 0603d31c367f7e726e4db6e249d4b62025c768000d43b02259a65e8486812362
-    - image: solr:7
+    - image: solr:8
       command: bin/solr -cloud -noprompt -f -p 8983
     steps:
     - checkout

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -208,12 +208,16 @@ class CatalogController < ApplicationController
     config.add_search_field 'all_fields', label: 'Everything'
     config.add_search_field 'title', label: 'Title' do |field|
       field.solr_parameters = {
-        qf: '${title_qf}'
+        qf: '${title_qf}',
+        pf: '${title_pf}'
       }
     end
     config.add_search_field 'author', label: 'Creator / Contributor' do |field|
       field.solr_parameters = {
-        qf: '${author_qf}'
+        qf: '${author_qf}',
+        pf: '${author_pf}'
+      }
+    end
       }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -218,6 +218,12 @@ class CatalogController < ApplicationController
         pf: '${author_pf}'
       }
     end
+    config.add_search_field 'identifier', label: 'Identifier' do |field|
+      field.solr_parameters = {
+        qf: '${identifier_qf}',
+        pf: '${identifier_pf}',
+        pf2: '${identifier_pf2}',
+        pf3: '${identifier_pf3}'
       }
     end
 

--- a/app/resource_builders/dlme_json_resource_builder.rb
+++ b/app/resource_builders/dlme_json_resource_builder.rb
@@ -51,6 +51,8 @@ class DlmeJsonResourceBuilder < Spotlight::SolrDocumentBuilder
       if sink['agg_is_shown_at.wr_is_referenced_by_ssim']
         sink['agg_is_shown_at.wr_is_referenced_by_ssi'] = Array(sink['agg_is_shown_at.wr_is_referenced_by_ssim']).first
       end
+
+      sink['cho_title_creator_tsim'] = (Array(sink['cho_title_ssim']) + Array(sink['cho_creator_ssim'])).join("\n")
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -107,9 +107,8 @@
   <copyField source="cho_contributor_tsim" dest="cho_contributor_tesim" />
   <copyField source="cho_contributor_tsim" dest="cho_contributor_tfasim" />
   <copyField source="cho_contributor_tsim" dest="cho_contributor_ttrsim" />
-  <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
 
+  <copyField source="*_ssim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*.en_ssim" dest="all_text.en_timv" maxChars="3000"/>
   <copyField source="*.ar-Arab_ssim" dest="all_text.ar_timv" maxChars="3000"/>
 

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -73,6 +73,9 @@
 
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <field name="all_text.ar_timv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <field name="all_text.en_timv" type="text_ar" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+
   </fields>
 
 
@@ -106,6 +109,9 @@
   <copyField source="cho_contributor_tsim" dest="cho_contributor_ttrsim" />
   <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
   <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
+
+  <copyField source="*.en_ssim" dest="all_text.en_timv" maxChars="3000"/>
+  <copyField source="*.ar-Arab_ssim" dest="all_text.ar_timv" maxChars="3000"/>
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -82,6 +82,7 @@
       copyField also supports a maxChars to copy setting.  -->
 
   <copyField source="id" dest="id_ng" maxChars="3000"/>
+  <copyField source="cho_identifier_ssim" dest="cho_identifier_tsim" />
   <copyField source="cho_title_tsim" dest="cho_title_ng" maxChars="3000"/>
   <copyField source="cho_title_tsim" dest="cho_title_exact_tsim" />
   <copyField source="cho_title_tsim" dest="cho_title_tarsim" />

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -32,7 +32,7 @@
        <str name="q.alt">*:*</str>
        <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
        <int name="qs">1</int>
-       <int name="ps">2</int>
+       <int name="ps">1</int>
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -137,14 +137,22 @@
          cho_identifier_ssim^5000
          cho_identifier_tsim^1000
        </str>
-       <str name="subject_qf">
-          cho_coverage_tsim
-          cho_spatial_tsim
-          cho_temporal_tsim
+       <str name="identifier_pf">
+         id^10000
+         cho_identifier_ssim^5000
+         cho_identifier_tsim^1000
        </str>
-       <str name="subject_pf">
+       <str name="identifier_pf2">
+         id^10000
+         cho_identifier_ssim^5000
+         cho_identifier_tsim^300
        </str>
-       
+       <str name="identifier_pf3">
+         id^10000
+         cho_identifier_ssim^5000
+         cho_identifier_tsim^700
+       </str>
+
        <str name="fl">
          *,
          score

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -88,7 +88,20 @@
           cho_contributor_fuzzy_tsim
        </str>
        <str name="author_pf">
+          cho_creator_tsim^5000
+          cho_contributor_tsim^3000
+          cho_creator_tarsim^220
+          cho_creator_tesim^220
+          cho_creator_tfasim^220
+          cho_creator_ttrsim^220
+          cho_contributor_tarsim^200
+          cho_contributor_tesim^200
+          cho_contributor_tfasim^200
+          cho_contributor_ttrsim^200
+          cho_creator_fuzzy_tsim^50
+          cho_contributor_fuzzy_tsim^50
        </str>
+
        <str name="title_qf">
           cho_title_exact_tsim^100
           cho_alternative_exact_tsim^50
@@ -104,6 +117,25 @@
           cho_alternative_ttrsim
        </str>
        <str name="title_pf">
+         cho_title_exact_tsim^5000
+         cho_alternative_exact_tsim^2500
+         cho_title_tsim^1000
+         cho_alternative_tsim^500
+
+         cho_title_tarsim^250
+         cho_title_tesim^250
+         cho_title_tfasim^250
+         cho_title_ttrsim^250
+         cho_alternative_tarsim^50
+         cho_alternative_tesim^50
+         cho_alternative_tfasim^50
+         cho_alternative_ttrsim^50
+       </str>
+
+       <str name="identifier_qf">
+         id^10000
+         cho_identifier_ssim^5000
+         cho_identifier_tsim^1000
        </str>
        <str name="subject_qf">
           cho_coverage_tsim
@@ -114,7 +146,7 @@
        </str>
        
        <str name="fl">
-         *, 
+         *,
          score
        </str>
 
@@ -131,12 +163,12 @@
        <str name="defType">lucene</str>
      </lst>
   </requestHandler>
-  
-  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" /> 
-  
+
+  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
 </config>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -6,7 +6,7 @@
 
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
 
-  <luceneMatchVersion>8.2.0</luceneMatchVersion>
+  <luceneMatchVersion>8.7.0</luceneMatchVersion>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
 

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -36,41 +36,149 @@
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
        -->
         <str name="qf">
-          id
-          cho_title_exact_tsim^5000
-          cho_alternative_exact_tsim^2500
-          cho_title_tsim^1000
-          cho_alternative_tsim^500
+          id^10000
+          cho_identifier_ssim^5000
+          cho_identifier_ssim^5
 
-          cho_title_tarsim^50
-          cho_title_tesim^50
-          cho_title_tfasim^50
-          cho_title_ttrsim^50
+          cho_title_exact_tsim^1000
+          cho_alternative_exact_tsim^500
+          cho_title_tsim^700
+          cho_alternative_tsim^300
+
+          cho_title_tarsim^150
+          cho_title_tesim^150
+          cho_title_tfasim^150
+          cho_title_ttrsim^150
           cho_alternative_tarsim^10
           cho_alternative_tesim^10
           cho_alternative_tfasim^10
           cho_alternative_ttrsim^10
-          cho_creator_tarsim^100
-          cho_creator_tesim^100
-          cho_creator_tfasim^100
-          cho_creator_ttrsim^100
+          cho_creator_tarsim^120
+          cho_creator_tesim^120
+          cho_creator_tfasim^120
+          cho_creator_ttrsim^120
           cho_contributor_tarsim^100
           cho_contributor_tesim^100
           cho_contributor_tfasim^100
           cho_contributor_ttrsim^100
 
+          cho_title_creator_tsim^50
           cho_creator_fuzzy_tsim
           cho_contributor_fuzzy_tsim
-          all_text_timv
+          all_text_timv^15
+          all_text.en_timv^5
+          all_text.ar_timv^5
         </str>
+
         <str name="pf">
-          all_text_timv^10
+          cho_title_exact_tsim^5000
+          cho_alternative_exact_tsim^2500
+          cho_title_tsim^1000
+          cho_alternative_tsim^500
+
+          cho_title_tarsim^250
+          cho_title_tesim^250
+          cho_title_tfasim^250
+          cho_title_ttrsim^250
+          cho_alternative_tarsim^50
+          cho_alternative_tesim^50
+          cho_alternative_tfasim^50
+          cho_alternative_ttrsim^50
+          cho_creator_tarsim^220
+          cho_creator_tesim^220
+          cho_creator_tfasim^220
+          cho_creator_ttrsim^220
+          cho_contributor_tarsim^200
+          cho_contributor_tesim^200
+          cho_contributor_tfasim^200
+          cho_contributor_ttrsim^200
+          cho_creator_fuzzy_tsim^50
+          cho_contributor_fuzzy_tsim^50
+          cho_title_creator_tsim^50
+
+          cho_coverage_tsim^25
+          cho_spatial_tsim^25
+          cho_temporal_tsim^25
+
+          all_text_timv^15
+          all_text.en_timv^5
+          all_text.ar_timv^5
+        </str>
+
+        <str name="pf2">
+          cho_title_exact_tsim^3000
+          cho_alternative_exact_tsim^700
+          cho_title_tsim^300
+          cho_alternative_tsim^100
+
+          cho_title_tarsim^50
+          cho_title_tesim^50
+          cho_title_tfasim^50
+          cho_title_ttrsim^50
+          cho_alternative_tarsim^50
+          cho_alternative_tesim^50
+          cho_alternative_tfasim^50
+          cho_alternative_ttrsim^50
+          cho_creator_tarsim^20
+          cho_creator_tesim^20
+          cho_creator_tfasim^20
+          cho_creator_ttrsim^20
+          cho_contributor_tarsim^00
+          cho_contributor_tesim^00
+          cho_contributor_tfasim^00
+          cho_contributor_ttrsim^00
+          cho_creator_fuzzy_tsim^50
+          cho_contributor_fuzzy_tsim^50
+          cho_title_creator_tsim^50
+
+          cho_coverage_tsim^5
+          cho_spatial_tsim^5
+          cho_temporal_tsim^5
+
+          all_text_timv^15
+          all_text.en_timv^5
+          all_text.ar_timv^5
+        </str>
+
+        <str name="pf3">
+          cho_title_exact_tsim^4000
+          cho_alternative_exact_tsim^1500
+          cho_title_tsim^700
+          cho_alternative_tsim^300
+
+          cho_title_tarsim^150
+          cho_title_tesim^150
+          cho_title_tfasim^150
+          cho_title_ttrsim^150
+          cho_alternative_tarsim^50
+          cho_alternative_tesim^50
+          cho_alternative_tfasim^50
+          cho_alternative_ttrsim^50
+          cho_creator_tarsim^120
+          cho_creator_tesim^120
+          cho_creator_tfasim^120
+          cho_creator_ttrsim^120
+          cho_contributor_tarsim^100
+          cho_contributor_tesim^100
+          cho_contributor_tfasim^100
+          cho_contributor_ttrsim^100
+          cho_creator_fuzzy_tsim^30
+          cho_contributor_fuzzy_tsim^30
+          cho_title_creator_tsim^80
+
+          cho_coverage_tsim^25
+          cho_spatial_tsim^25
+          cho_temporal_tsim^25
+
+          all_text_timv^15
+          all_text.en_timv^5
+          all_text.ar_timv^5
         </str>
 
        <str name="author_qf">

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -16,7 +16,7 @@
     </updateLog>
   </updateHandler>
 
-  <!-- solr lib dirs -->  
+  <!-- solr lib dirs -->
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
 
@@ -30,7 +30,7 @@
        <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
        <str name="q.alt">*:*</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+       <str name="mm">6&lt;-1 6&lt;90%</str>
        <int name="qs">1</int>
        <int name="ps">1</int>
        <float name="tie">0.01</float>


### PR DESCRIPTION
## Why was this change made?

This PR makes some generally best-practice improvements to our solr tuning, including adding phrase boosts to ensure that matching multiple near-adjacent terms increase the document relevancy score.

In addition:

Fixes #1103: adds fielded search for identifiers (and removed the unused subject search)  
Fixes #1106: increase the mm, not to 100%, but allows some leeway with longer query strings
Fixes #1105: adds additional fields containing textual data to the catch-all field so.. all means all.

Also, language-specific catch-all fields have been added for Arabic and English text to allow some fuzzy matching (with stemming, etc applied) across the catch-all data.  
 
## Was the documentation (README, API, wiki, ...) updated?
