### PR TITLE
Make sure that we follow redirects for the proxy thumbnails

### DIFF
--- a/app/controllers/image_proxy_controller.rb
+++ b/app/controllers/image_proxy_controller.rb
@@ -23,7 +23,7 @@ class ImageProxyController < ApplicationController
     @proxied_response ||= begin
       Rails.cache.fetch([image_url], expires_in: Settings.cache_period) do
         benchmark "Fetch #{image_url}" do
-          response = HTTP.get(image_url)
+          response = HTTP.follow.get(image_url)
           CacheableResponse.new(response.body.to_s, response.content_type.to_s)
         end
       end

--- a/spec/controllers/image_proxy_controller_spec.rb
+++ b/spec/controllers/image_proxy_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe ImageProxyController do
   describe 'GET access' do
     let(:image_response) { instance_double('HTTP::Response', body: '', content_type: 'image/jpeg') }
+    let(:http_client) { instance_double('HTTP::Client') }
 
     # rubocop:disable RSpec/BeforeAfterAll
     before(:all) do
@@ -15,7 +16,8 @@ RSpec.describe ImageProxyController do
     it 'proxies an image request' do
       allow(controller).to receive(:valid_authenticity_token?).and_return true
       # rubocop:disable RSpec/MessageSpies
-      expect(HTTP).to receive(:get).with('http://example.com/image1.jpg').and_return(image_response)
+      expect(HTTP).to receive(:follow).and_return http_client
+      expect(http_client).to receive(:get).with('http://example.com/image1.jpg').and_return(image_response)
       # rubocop:enable RSpec/MessageSpies
       request.headers['Referer'] = controller.search_catalog_url
       get :access, params: { url: 'http://example.com/image1.jpg' }


### PR DESCRIPTION
## Why was this change made?
This fixes an issue where http:// thumb urls that actually redirect to https:// are not followed.

@jacobthill is updating some of the transforms (contentdm) ones that presented this problem, but this will follow redirects in the future so that users won't notice any problems.