### PR TITLE
Update to latest 3.x blacklight-gallery releaes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,5 @@ gem 'cache_with_locale'
 
 gem 'i18n-js'
 gem 'i18n-tasks'
+
+gem 'openseadragon', '>= 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,10 +137,9 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-gallery (2.1.0)
-      blacklight (~> 7.7)
+    blacklight-gallery (3.0.1)
+      blacklight (~> 7.12)
       bootstrap (~> 4.0)
-      openseadragon (>= 0.2.0)
       rails (>= 5.1, < 7)
     blacklight-hierarchy (4.3.0)
       blacklight (~> 7.13)
@@ -681,6 +680,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   okcomputer
+  openseadragon (>= 0.2.0)
   pg
   puma (~> 3.7)
   rack-attack

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+
+//= link openseadragon-assets

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require bootstrap
 //= require bootstrap/util
 //= require blacklight/blacklight
+//= require blacklight_gallery
 
 //= require transform_result
 //= require i18n/translations

--- a/app/assets/javascripts/blacklight_gallery.js
+++ b/app/assets/javascripts/blacklight_gallery.js
@@ -1,1 +1,2 @@
 //= require blacklight_gallery/default
+//= require blacklight_gallery/osd_viewer

--- a/app/assets/stylesheets/blacklight_gallery.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery.css.scss
@@ -1,0 +1,3 @@
+/*
+ *= require blacklight_gallery/default
+ */

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -77,7 +77,7 @@ h2, .h2 {
 
 body {
   background-color: $body-background-color;
-  color: $gray-dark;
+  color: $color-gray-dark;
   margin-bottom: $footer-height + $footer-top-margin;
 
   @include media-breakpoint-down('md') {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,6 +14,12 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
+    config.view.gallery.document_component = Blacklight::Gallery::DocumentComponent
+    # config.view.gallery.classes = 'row-cols-2 row-cols-md-3'
+    config.view.masonry.document_component = Blacklight::Gallery::DocumentComponent
+    config.view.slideshow.document_component = Blacklight::Gallery::SlideshowComponent
+    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
+    config.show.partials.insert(1, :openseadragon)
     # Disable bookmarks
     config.index.document_actions[:bookmark].if = false
     config.show.document_actions[:bookmark].if = false
@@ -25,8 +31,6 @@ class CatalogController < ApplicationController
     config.show.partials = %i[show_header show_with_viewer ir_view]
 
     config.view.list.partials = %i[thumbnail index_header index]
-    config.view.gallery.partials = %i[index_header index]
-    config.view.slideshow.partials = [:index]
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)


### PR DESCRIPTION
In draft until we have a release of Blacklight that can allow the gallery component to inject the necessary css class

## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
