### PR TITLE
Update configuration to support blacklight-gallery 2.1.0 -> 3.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'iiif-presentation', '~> 1.0'
 gem 'riiif', '~> 2.0'
 gem 'sitemap_generator'
 
-gem 'blacklight-gallery', '~> 2.1.0'
+gem 'blacklight-gallery', '~> 3.0'
 gem 'blacklight-hierarchy'
 gem 'blacklight-oembed', '>= 0.1.0'
 gem 'blacklight_range_limit', github: 'projectblacklight/blacklight_range_limit', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,10 +154,9 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7)
       view_component (>= 2.23.0)
-    blacklight-gallery (2.1.0)
-      blacklight (~> 7.7)
+    blacklight-gallery (3.0.1)
+      blacklight (~> 7.12)
       bootstrap (~> 4.0)
-      openseadragon (>= 0.2.0)
       rails (>= 5.1, < 7)
     blacklight-hierarchy (5.0.0)
       blacklight (~> 7.13)
@@ -652,7 +651,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-sns
   blacklight (~> 7.14)
-  blacklight-gallery (~> 2.1.0)
+  blacklight-gallery (~> 3.0)
   blacklight-hierarchy
   blacklight-oembed (>= 0.1.0)
   blacklight-spotlight!

--- a/app/assets/stylesheets/blacklight_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery.scss
@@ -1,10 +1,10 @@
 @import 'blacklight_gallery/default';
 
-.gallery {
+.documents-gallery {
   .document {
     margin-bottom: 0.75rem;
 
-    .thumbnail {
+    .thumbnail-container {
       background-color: $color-gray-lighter;
       border: 1px solid darken($color-gray-lighter, 6%);
       border-radius: 5px;

--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -4,7 +4,7 @@ h6, .h1, .h2, .h3, .h4,
 .facets-heading, .h5,
 .page-sidebar .nav-heading,
 .h6, .facet-field-heading,
-.gallery .index_title {
+.documents-gallery .index_title {
   font-weight: 400;
   line-height: 1;
 }
@@ -145,7 +145,7 @@ body {
   color: $color-black-medium;
 }
 
-.thumbnail {
+.thumbnail-container {
   background-color: transparent;
   border: 0;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,8 +25,9 @@ class CatalogController < ApplicationController
     config.show.partials = %i[show_header show_with_viewer ir_view record_feedback]
 
     config.view.list.partials = %i[thumbnail index_header index]
-    config.view.gallery.partials = %i[index_header index]
-    config.view.slideshow.partials = [:index]
+    config.view.gallery.document_component = Blacklight::Gallery::DocumentComponent
+    config.view.masonry.document_component = Blacklight::Gallery::DocumentComponent
+    config.view.slideshow.document_component = Blacklight::Gallery::SlideshowComponent
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)

--- a/app/presenters/dlme_thumbnail_presenter.rb
+++ b/app/presenters/dlme_thumbnail_presenter.rb
@@ -6,7 +6,7 @@ class DlmeThumbnailPresenter < Blacklight::ThumbnailPresenter
   ##
   # Overridden to support lazy options
   def thumbnail_tag(image_options = {}, url_options = {})
-    super(image_options.merge(loading: 'lazy'), url_options)
+    super(image_options.merge(loading: 'lazy', class: 'img-thumbnail'), url_options)
   end
 
   private

--- a/spec/presenters/dlme_thumbnail_presenter_spec.rb
+++ b/spec/presenters/dlme_thumbnail_presenter_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe DlmeThumbnailPresenter do
   describe '#thumbnail_tag' do
     it 'merges in lazy attribute' do
       # rubocop:disable RSpec/MessageSpies
-      expect(view_context).to receive(:image_tag).with('https://www.example.com/image.png', { loading: 'lazy' })
+      expect(view_context).to receive(:image_tag).with(
+        'https://www.example.com/image.png',
+        { class: 'img-thumbnail', loading: 'lazy' }
+      )
       # rubocop:enable RSpec/MessageSpies
       presenter.thumbnail_tag
     end


### PR DESCRIPTION
## Why was this change made?
A follow on to upstream work in Spotlight and Blacklight-Gallery, this supports the upstream changes made there.

We should hold until Blacklight v7.15.0 is released with the thumbnail arity enhancement

Update: Now updated!

## Current vs Update

![Screen Shot 2021-02-01 at 5 49 17 PM](https://user-images.githubusercontent.com/1656824/106536522-dcba7f00-64b5-11eb-957f-baacb15147d1.png)
