### PR TITLE
Update exhibit feedback form

### DIFF
--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -1,0 +1,24 @@
+<% # Overridden from Spotlight to change markup around reporting_from text. We might be able to remove this override with a better seam %>
+<% # Copied from spotlight 3.0.0.rc2 %>
+<div class="container">
+  <div class="row justify-content-center">
+    <% contact_form ||= Spotlight::ContactForm.new current_url: request.original_url %>
+    <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 my-3 '} do |f| %>
+      <h2><%= t(:'.title') %></h2>
+      <div class="mb-5 text-center">
+        <%= t('.reporting_from') %>
+      </div>
+      <%= f.text_area :message, rows: 4 %>
+      <%= f.text_field :name %>
+      <%= render '/spotlight/shared/honeypot_field', f: f %>
+      <%= f.email_field :email %>
+      <%= f.hidden_field :current_url %>
+      <div class="form-actions row">
+        <div class="col offset-sm-3">
+          <%= f.submit nil, class: 'btn btn-primary' %>
+          <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn-sizing', data: { 'behavior' => 'cancel-link' } %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,11 +52,16 @@ en:
       sidebar:
         sources: Sources
         transform: Transform data
+    header_links:
+      contact: Contact us
     main_navigation:
       statistics: Statistics
     resources:
       fetch:
         queued: Queued for processing.
+    shared:
+      report_a_problem:
+        reporting_from: To contact us about any matter related to DLME, please use the form below.
     sites:
       edit:
         exhibit_home: Exhibit home

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,8 @@
 feature_flags:
   allow_json_upload: true
+
+action_mailer:
+  default_options:
+    from: tcramer1@example.com
+  default_url_options:
+    host: example.com

--- a/spec/features/contact_form_override_spec.rb
+++ b/spec/features/contact_form_override_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Contact form override', type: :feature do
+  let!(:exhibit) { FactoryBot.create(:exhibit) }
+
+  describe 'when emails are setup' do
+    before do
+      exhibit.contact_emails_attributes = [{ 'email' => 'test@example.com' }, { 'email' => 'test2@example.com' }]
+      exhibit.save!
+      exhibit.contact_emails.first.tap do |e|
+        if e.respond_to? :confirm
+          e.confirm
+        else
+          e.confirm!
+        end
+      end
+    end
+
+    it 'accepts a problem report', js: true do
+      visit spotlight.exhibit_path(exhibit)
+      click_on 'Contact us'
+      expect(page).to have_content 'To contact us about any matter related to DLME'
+      expect(page).not_to have_css('.alert-primary') # We removed this markup from the spotlight form
+      fill_in 'Your name', with: 'Some Body'
+      fill_in 'Your email', with: 'test@example.com'
+      fill_in 'Message', with: 'This is my problem report'
+
+      expect do
+        click_on 'Send'
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
Closes #1116 

## Was the documentation (README, API, wiki, ...) updated?

<img width="1188" alt="feedback-form-updates" src="https://user-images.githubusercontent.com/96776/105258424-9b81b100-5b3e-11eb-9fcf-665d37ac7feb.png">
