### PR TITLE
Add a feedback button to records

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -326,6 +326,14 @@ body {
   margin-bottom: 2rem;
 }
 
+.record-feedback {
+  position: fixed;
+  right: 0;
+  top: 49%;
+  transform: rotate(-90deg);
+  transform-origin: right bottom;
+}
+
 // Overrides for mobile viewports
 @media (max-width: 767px) {
   .navbar-default .navbar-form {

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -161,4 +161,11 @@ $breadcrumb-item-padding-x: 0.5rem !default;
       margin-right: 0;
     }
   }
+
+  .record-feedback {
+    left: 0;
+    right: auto;
+    transform: rotate(90deg);
+    transform-origin: left bottom;
+  }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,7 +22,7 @@ class CatalogController < ApplicationController
     config.navbar.partials = {}
 
     config.show.oembed_field = :"agg_is_shown_at.wr_id_ssim"
-    config.show.partials = %i[show_header show_with_viewer ir_view]
+    config.show.partials = %i[show_header show_with_viewer ir_view record_feedback]
 
     config.view.list.partials = %i[thumbnail index_header index]
     config.view.gallery.partials = %i[index_header index]

--- a/app/controllers/record_feedback_controller.rb
+++ b/app/controllers/record_feedback_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+##
+# Subclass of the ContactFormsController used for Record Feedback
+# We're overriding to build from our RecordFeedbackForm class and
+# to redirect to the correct place and set the correct notice
+class RecordFeedbackController < Spotlight::ContactFormsController
+  def create
+    if @contact_form.valid?
+      Spotlight::ContactMailer.report_problem(@contact_form).deliver_now
+
+      redirect_back(
+        fallback_location: spotlight.exhibit_solr_document_path(current_exhibit),
+        notice: t(:'helpers.submit.record_feedback.created')
+      )
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def build_contact_form
+    @contact_form = RecordFeedbackForm.new(contact_form_params)
+    @contact_form.current_exhibit = current_exhibit
+    @contact_form.request = request
+    @contact_form
+  end
+end

--- a/app/models/record_feedback_form.rb
+++ b/app/models/record_feedback_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+##
+# Subclass of Spotlight::ContactForm to inject our subject into the headers
+# and change how the validations work under the RecordFeedbackForm context
+class RecordFeedbackForm < Spotlight::ContactForm
+  clear_validators! # Remove upstream validators and define our own.
+  validates :message, presence: true
+  # rubocop:disable Style/RedundantRegexpEscape, Style/RedundantRegexpCharacterClass
+  # Disabling these rubocop checks because this regex comes from Blacklight
+  validates :email, format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }, allow_blank: true
+  # rubocop:enable Style/RedundantRegexpEscape, Style/RedundantRegexpCharacterClass
+
+  # the spambot_honeypot_email_field field is intended to be hidden visually from the user,
+  # in hope that a spam bot filling out the form will enter a value, whereas a human with a
+  # browser wouldn't, allowing us to differentiate and reject likely spam messages.
+  # the field must be present, since we expect real users to just submit the form as-is w/o
+  # hacking what fields are present.
+  validates Spotlight::Engine.config.spambot_honeypot_email_field, length: { is: 0 }
+
+  def headers
+    super.merge(subject: I18n.t(:'record_feedback.email_subject'))
+  end
+end

--- a/app/views/catalog/_record_feedback.html.erb
+++ b/app/views/catalog/_record_feedback.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t('record_feedback.header'), exhibit_record_feedback_path(current_exhibit), class: 'record-feedback btn btn-sm btn-primary', data: { 'blacklight-modal': 'trigger' } %>

--- a/app/views/record_feedback/new.html.erb
+++ b/app/views/record_feedback/new.html.erb
@@ -1,0 +1,24 @@
+<%= render Blacklight::System::ModalComponent.new do |component| %>
+  <% component.with(:title, t('record_feedback.header')) %>
+
+  <% component.with(:body) do %>
+    <%= bootstrap_form_for(@contact_form || Spotlight::ContactForm.new(current_url: request.original_url), url: exhibit_record_feedback_path(current_exhibit), as: 'contact_form') do |f| %>
+      <%= render '/spotlight/shared/honeypot_field', f: f %>
+      <%= f.hidden_field :current_url %>
+
+      <div class="modal-body">
+        <div class="mb-3">
+          <%= t('.form_help') %>
+        </div>
+
+        <%= f.text_area :message, rows: 4, label: t('.message') %>
+        <%= f.email_field :email, label: t('.email') %>
+      </div>
+
+      <div class="modal-footer">
+        <%= button_tag(t('.close'), class: 'btn btn-outline-dark', data: { 'dismiss': 'modal' }) if request.xhr? %>
+        <%= submit_tag t('.submit'), class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -41,6 +41,8 @@ ar:
     partnership_heading: بالشراكة مع
     project_support_heading: المشروع مدعوم من قبل
     project_support_text: مؤسسة أندرو و. ميلون
+  record_feedback:
+    header: ملاحظات واقتراحات
   s3_delete:
     new:
       add_item: احذف العناصر

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,19 @@ en:
     partnership_heading: In partnership with
     project_support_heading: Project supported by
     project_support_text: The Andrew W. Mellon Foundation
+  helpers:
+    submit:
+      record_feedback:
+        created: Your feedback has been submitted. Thank you. We will take care of it as soon as possible.
+  record_feedback:
+    email_subject: DLME item feedback
+    header: Feedback
+    new:
+      close: Close
+      email: Email address (optional)
+      form_help: If you have any questions or comments regarding this item, please let us know using the form below.
+      message: Question or comment
+      submit: Submit
   s3_delete:
     new:
       add_item: Delete Items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
       get "catalog/range_limit" => "spotlight/catalog#range_limit"
       get "home/range_limit" => "spotlight/home_pages#range_limit"
       get "catalog/range_limit_panel/:id" => "spotlight/catalog#range_limit_panel"
+      get "catalog/:id/record_feedback" => "record_feedback#new", as: 'record_feedback'
+      post "catalog/:id/record_feedback" => "record_feedback#create"
       get "home/range_limit_panel/:id" => "spotlight/home_pages#range_limit_panel"
     end
 

--- a/spec/controllers/record_feedback_controller_spec.rb
+++ b/spec/controllers/record_feedback_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecordFeedbackController, type: :controller do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+
+  before do
+    request.env['HTTP_REFERER'] = 'http://example.com'
+    exhibit.contact_emails_attributes = [{ 'email' => 'test@example.com' }, { 'email' => 'test2@example.com' }]
+    exhibit.save!
+    exhibit.contact_emails.first.tap do |e|
+      if e.respond_to? :confirm
+        e.confirm
+      else
+        e.confirm!
+      end
+    end
+  end
+
+  describe 'POST create' do
+    it 'sends an email' do
+      expect do
+        post(
+          :create,
+          params: {
+            exhibit_id: exhibit.id,
+            id: 'abc123',
+            contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', message: 'Great record!', honeypot_field_name => '' }
+          }
+        )
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it 'redirects back' do
+      post(
+        :create,
+        params: {
+          exhibit_id: exhibit.id,
+          id: 'abc123',
+          contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', message: 'Great record!', honeypot_field_name => '' }
+        }
+      )
+      expect(response).to redirect_to 'http://example.com'
+    end
+
+    it 'sets a flash message' do
+      post(
+        :create,
+        params: {
+          exhibit_id: exhibit.id,
+          id: 'abc123',
+          contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', message: 'Great record!', honeypot_field_name => '' }
+        }
+      )
+      expect(flash[:notice]).to eq 'Your feedback has been submitted. Thank you. We will take care of it as soon as possible.'
+    end
+  end
+end

--- a/spec/features/record_feedback_spec.rb
+++ b/spec/features/record_feedback_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Record Feedback', type: :feature do
+  let(:exhibit) { create(:exhibit, published: true) }
+  let(:resource) { DlmeJson.new(json: json, metadata: metadata, exhibit: exhibit) }
+  let(:fixture_file_path) { File.join(fixture_path, 'json/bodleian.json') }
+  let(:json) { File.open(fixture_file_path).read }
+  let(:metadata) do
+    { 'traject_context_command_line.filename' => fixture_file_path,
+      'traject_context_source' => 'dlme_json_resource_spec' }
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :inline # block until indexing has committed
+    resource.save_and_index
+
+    exhibit.contact_emails_attributes = [{ 'email' => 'test@example.com' }]
+    exhibit.save!
+    exhibit.contact_emails.first.tap do |e|
+      if e.respond_to? :confirm
+        e.confirm
+      else
+        e.confirm!
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  it 'allows users to submit feedback', js: true do
+    visit spotlight.exhibit_solr_document_path(exhibit_id: exhibit.slug, id: '36ebabd9-4d62-4d8e-8e7b-1afd048e872e')
+
+    expect(page).to have_css('a.record-feedback', text: 'Feedback')
+    click_link 'Feedback'
+
+    expect(page).to have_css '#blacklight-modal', visible: :visible
+
+    within '#blacklight-modal' do
+      fill_in 'Question or comment', with: 'This record is one of the best I have seen all day'
+      expect do
+        click_button 'Submit'
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    expect(page).to have_css(
+      '.flash_messages .alert-info',
+      text: 'Your feedback has been submitted. Thank you. We will take care of it as soon as possible.'
+    )
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  it 'can get to the form w/o javascript' do
+    visit spotlight.exhibit_solr_document_path(exhibit_id: exhibit.slug, id: '36ebabd9-4d62-4d8e-8e7b-1afd048e872e')
+
+    expect(page).to have_css('a.record-feedback', text: 'Feedback')
+    click_link 'Feedback'
+
+    expect(page).to have_css('h1', text: 'Feedback')
+    expect(current_url).to eq exhibit_record_feedback_url(exhibit_id: exhibit.slug, id: '36ebabd9-4d62-4d8e-8e7b-1afd048e872e')
+  end
+end

--- a/spec/models/record_feedback_form_spec.rb
+++ b/spec/models/record_feedback_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecordFeedbackForm do
+  context 'when validating feedback submission fields' do
+    let(:form) { described_class.new(email: 'user@example.com') }
+    let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+
+    it 'allows submissions that set a valid email address & message' do
+      form.message = 'This is a great record'
+      form.email = 'user@legitimatebusinesspersonssocialclub.biz'
+      form.send("#{honeypot_field_name}=", '')
+      expect(form).to be_valid
+    end
+
+    it 'rejects submissions that set an invalid email address' do
+      form.message = 'This is a great record'
+      form.email = 'user'
+      form.send("#{honeypot_field_name}=", '')
+      expect(form).not_to be_valid
+    end
+
+    it 'allows submissions that leave the spammer honeypot field blank' do
+      form.message = 'This is a great record'
+      form.send("#{honeypot_field_name}=", '')
+      expect(form).to be_valid
+    end
+
+    it 'rejects submissions that set the spammer honeypot field' do
+      form.message = 'This is a great record'
+      form.send("#{honeypot_field_name}=", 'spam@spam.com')
+      expect(form).not_to be_valid
+    end
+
+    it 'rejects submissions that do not set a message' do
+      form.send("#{honeypot_field_name}=", '')
+      expect(form).not_to be_valid
+    end
+
+    it 'allows submissions that do not include an email' do
+      form.message = 'This is a great record'
+      form.email = nil
+      form.send("#{honeypot_field_name}=", '')
+      expect(form).to be_valid
+    end
+  end
+
+  describe '#headers' do
+    it 'overrides the described_class.new key in the super class\' hash' do
+      expect(described_class.new.headers[:subject]).to end_with 'item feedback'
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
Closes #146

## Was the documentation (README, API, wiki, ...) updated?

https://user-images.githubusercontent.com/96776/105427725-9b4ae980-5c02-11eb-99d4-fe1169339064.mov

Resulting email:

```
To: test@example.com
Cc: test@example.com
Message-ID: <600a16a99bb2e_12b0122588933a1@li-dl-7475-708c.local.mail>
Subject: DLME item feedback
Mime-Version: 1.0
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <style>
      /* Email styles need to be inline */
    </style>
  </head>

  <body>
    <p></p>
<p>From: &quot;&quot; &lt;&gt;</p>

<p>This site is great, and this record in particular is REALLY good!</p>

----

<dl>
  <dt>REMOTE_IP</dt><dd>::1</dd>
  <dt>USER AGENT</dt><dd>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36</dd>
  <dt>EXHIBIT</dt><dd>Test Exhibit</dd>
  <dt>CURRENT_URL</dt><dd>http://localhost:3000/en/test-exhibit/catalog/b17775905</dd>
  <dt>UUID</dt><dd>5cc49814-35b6-4f2a-aafd-8ae6b7ab5d06</dd>
</dl>
  </body>
</html>
```

