### PR TITLE
Increase bootstrap z-indexes by 1000 so our application will always be…

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -2,6 +2,14 @@
 
 $font-family-base: 'Markazi Text', $font-family-sans-serif;
 
+$zindex-dropdown: $zindex-dropdown + 1000;
+$zindex-sticky: $zindex-sticky + 1000;
+$zindex-fixed: $zindex-fixed + 1000;
+$zindex-modal-backdrop: $zindex-modal-backdrop + 1000;
+$zindex-modal: $zindex-modal + 1000;
+$zindex-popover: $zindex-popover + 1000;
+$zindex-tooltip: $zindex-tooltip + 1000;
+
 a .figure-caption {
   color: inherit;
 }


### PR DESCRIPTION
… "on top" of Mirador (e.g. modals, menus, etc)

Attempting to address: 

<img width="1151" alt="Screen Shot 2021-01-21 at 6 46 55 PM" src="https://user-images.githubusercontent.com/96776/105439180-364ebe00-5c19-11eb-9752-fbb7d56b83ad.png">

[MUI's Z-Indexes](https://material-ui.com/customization/z-index/) range from 1000 - 1500
[Bootstrap's Z-Indexes](https://github.com/twbs/bootstrap/blob/c6d6160a7c2203fbe620b6e4a660f72c40b2efd3/scss/_variables.scss#L846-L852) range from 1000 - 1070 (2000 - 2070 after this change)