### PR TITLE
Remove indent on Date Range facet value label

### DIFF
--- a/app/assets/stylesheets/custom_blacklight_range_limit.scss
+++ b/app/assets/stylesheets/custom_blacklight_range_limit.scss
@@ -1,3 +1,10 @@
-.custom-range-limit-container .load_distribution {
-  display: none;
+.custom-range-limit-container {
+  .load_distribution {
+    display: none;
+  }
+
+  .facet-values .facet-label {
+    padding-left: 0;
+    text-indent: 0;
+  }
 }


### PR DESCRIPTION
Fixes #1141.

This PR removes the left indent facet value labels get when they wrap to multiple lines.

The indent makes sense for most facet value labels because it helps distinguish values that wrap from the next value in the vertical list of values. But in the Date range facet there is only ever one facet value displayed, and removing the left indent gives the value a bit more horizontal space to use before wrapping. So this change only affects the facet value label in the Date range widget and leaves facet value labels in other facets alone.

## Before
<img width="235" alt="Screen Shot 2021-01-22 at 2 29 59 PM" src="https://user-images.githubusercontent.com/101482/105551930-7d43be80-5cc0-11eb-84e5-ea62c4eced29.png">

## After
<img width="235" alt="Screen Shot 2021-01-22 at 2 37 59 PM" src="https://user-images.githubusercontent.com/101482/105551978-8a60ad80-5cc0-11eb-859d-f3fe69599ba7.png">

## Note to Jacob
@jacobthill I can't reproduce your screenshot in #1141, where the date value wraps several times. I tried the three main browsers with the same date values and all look like my Before screenshot above. 

In any case, this is a worthwhile thing to do even if that was an anomaly; as my before/after screenshots show, it reduces three lines to two and just generally looks better.