### PR TITLE
Adjust facet header background color to match gallery thumb background color

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -283,11 +283,11 @@ body {
 }
 
 .facet-limit {
-  border: 1px solid $color-gray-medium;
+  border: 1px solid darken($color-gray-lighter, 6%);
   margin-bottom: 0.5rem;
 
   .card-header {
-    background-color: $color-gray-light;
+    background-color: $color-gray-lighter;
     border-bottom: 0;
   }
 }


### PR DESCRIPTION
This is pretty subtle but the facet headers are using shades of gray that are close but _different_ than the background color/border colors of the gallery view thumbnail container. They either need to be noticeably different or the same, so this PR makes them use the same colors.

### Before
<img width="1159" alt="Screen Shot 2021-01-27 at 3 34 27 PM" src="https://user-images.githubusercontent.com/101482/106063586-a6e05980-60b5-11eb-99f3-2ee2ca6971d6.png">

### After
<img width="1159" alt="Screen Shot 2021-01-27 at 3 02 47 PM" src="https://user-images.githubusercontent.com/101482/106063607-ae9ffe00-60b5-11eb-8802-eda556964d96.png">
