### PR TITLE
Override column specification for gallery view metadata

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery.scss
@@ -32,6 +32,7 @@
     }
 
     dd {
+      @extend .col-md-12;
       flex-basis: 100%;
       line-height: 1.2;
     }


### PR DESCRIPTION
A ramification of the recent change to hide the metadata field label in gallery view is that the metadata field values only have 9 cols in the metadata display area (because the field label gets 3 cols, which aren't displayed now). This leaves extra unused space (3 cols worth) in each line of metadata, which causes text wrapping sooner than it needs to:

<img width="730" alt="Screen Shot 2021-01-27 at 3 53 19 PM" src="https://user-images.githubusercontent.com/101482/106065429-8c5baf80-60b8-11eb-8bfb-25307d3a328a.png">

The value indicated above wraps to 3 lines.

This PR overrides the column specification for the metadata field values in gallery view, giving them all 12 columns to work with. As a result, the value above now only requires 2 lines:

<img width="730" alt="Screen Shot 2021-01-27 at 3 54 00 PM" src="https://user-images.githubusercontent.com/101482/106065605-c3ca5c00-60b8-11eb-9712-8eed95f4ad73.png">

---

The effect is more dramatic in other records with longer metadata values (that I no longer have in my local index to use as examples).

The only drawback I see with this is if we ever change our mind and want to display the metadata field labels in gallery view, we'd have to revert this update to go back to the default 3/9 column split for metadata field label/value.