### PR TITLE
Use non-deprecated riiif cache config

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -13,4 +13,4 @@ end
 
 # Riiif.not_found_image = 'app/assets/images/us_404.svg'
 #
-Riiif::Engine.config.cache_duration_in_days = 365.days
+Riiif::Engine.config.cache_duration = 365.days


### PR DESCRIPTION
DEPRECATION WARNING: Riiif::Engine.config.cache_duration_in_days is deprecated; use #cache_duration instead and pass a fully-qualified date (e.g., `3.days`).