### PR TITLE
Update padding of language switcher in the date slider facet in rtl …

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -42,6 +42,10 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     font-family: $font-family-base;
   }
 
+  .form-check {
+    padding-right: 1.25rem;
+    padding-left: inherit;
+  }
 
   /** Upstream is a little too eager reseting styles.. */
   .list-unstyled {

--- a/app/views/blacklight_range_limit/_custom_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_custom_range_limit_panel.html.erb
@@ -8,7 +8,7 @@
   <form autocomplete="off">
     <div class="form-group">
       <div class="row">
-        <legend class="col-form-label col-sm-2 col-lg-5 pt-0 pr-0"><%= t('date_range_calendar') %></legend>
+        <legend class="col-form-label col-sm-2 col-lg-5 pt-0 text-nowrap"><%= t('date_range_calendar') %></legend>
         <div class="col-sm-10 col-lg-7">
           <% facet_configuration[:configured_range_fields].each do |field| %>
             <div class="form-check">


### PR DESCRIPTION
…display.

Closes #1137 

## RTL
### Small viewport
<img width="397" alt="Screen Shot 2021-01-29 at 2 07 03 PM" src="https://user-images.githubusercontent.com/96776/106332531-dde07780-623b-11eb-8c62-a17cf3f4a7e2.png">


### Large viewport
<img width="248" alt="Screen Shot 2021-01-29 at 2 07 23 PM" src="https://user-images.githubusercontent.com/96776/106332332-732f3c00-623b-11eb-8d89-9e6e42c821f8.png">


---


## LTR

### Small viewport
<img width="229" alt="Screen Shot 2021-01-29 at 2 06 25 PM" src="https://user-images.githubusercontent.com/96776/106332343-79251d00-623b-11eb-8dd3-247edbadae69.png">


### Large viewport
<img width="471" alt="Screen Shot 2021-01-29 at 2 06 00 PM" src="https://user-images.githubusercontent.com/96776/106332344-79bdb380-623b-11eb-9e2f-6bf33a81550f.png">
