### PR TITLE
Limit height of gallery view thumbnails

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery.scss
@@ -17,6 +17,7 @@
       border-radius: 0;
       display: block;
       margin: 0 auto;
+      max-height: 200px;
     }
 
     .caption {


### PR DESCRIPTION
This is a first-pass at addressing @mwerla's [concern about the height of thumbnail images](https://github.com/sul-dlss/dlme/issues/1136#issuecomment-771598801) in gallery view. We can adjust the `max-height` value later after we assess the tradeoffs with the value set in this PR.

The issue addressed is that when there is a very vertically-oriented image in the gallery view results, it creates a very tall thumbnail area and forces the other items in its row to stretch to a unusually tall height. I went with limiting the height of thumbnail images to `200px` in this PR, which is a compromise between limiting the height of images while not reducing the width too much.

### Before example
Indicated item creates very tall row with a lot of empty space in its neighbor items.

<img width="981" alt="Screen Shot 2021-02-02 at 9 12 31 AM" src="https://user-images.githubusercontent.com/101482/106629723-5abf6a00-6538-11eb-88be-5c05a91e8d62.png">

### After example
Indicated item's height is limited, which also reduces its width, but not so much that it isn't still useful as a visual preview. Neighbor items are now more reasonable in height.

<img width="981" alt="Screen Shot 2021-02-02 at 9 13 14 AM" src="https://user-images.githubusercontent.com/101482/106629915-8f332600-6538-11eb-94c6-bb531e225fc0.png">

### Additional example
@mwerla Note that to get equal heights of images we'd have to go really far in limiting image height. For instance, below the setting is `max-height: 100px;` but in my opinion this is too drastic, as it reduces the width of tall items so much that there isn't much value in the image preview. And because it reduces the width of many other no-so-tall images, it creates a lot of whitespace around the images and reduces the overall visual appeal of the page.

<img width="981" alt="Screen Shot 2021-02-02 at 9 14 12 AM" src="https://user-images.githubusercontent.com/101482/106630249-e6d19180-6538-11eb-95a0-3a45397a0bb1.png">


