### PR TITLE
Allow nil URLs for DLMEJson (since direct JSON uploads have no URL)

### DIFF
--- a/app/models/dlme_json.rb
+++ b/app/models/dlme_json.rb
@@ -4,7 +4,7 @@
 class DlmeJson < Spotlight::Resource
   self.document_builder_class = DlmeJsonResourceBuilder
   validate :valid_json_syntax?
-  validates :url, uniqueness: { scope: :exhibit_id }
+  validates :url, uniqueness: { scope: :exhibit_id }, allow_nil: true
 
   store :data, accessors: %i[json metadata]
 

--- a/spec/models/dlme_json_spec.rb
+++ b/spec/models/dlme_json_spec.rb
@@ -21,6 +21,46 @@ RSpec.describe DlmeJson do
       end
     end
 
+    context 'with a url' do
+      let(:json) { File.read('spec/fixtures/json/embeddable.json') }
+
+      before do
+        instance.url = 'http://example.com'
+        instance.save
+      end
+
+      it 'the url is required to be unique' do
+        new_instance = described_class.new(
+          data: { json: json },
+          exhibit: exhibit,
+          url: 'http://example.com'
+        )
+
+        expect(new_instance).not_to be_valid
+        expect(new_instance.errors[:url].to_a).to eq(['has already been taken'])
+      end
+    end
+
+    context 'without a URL' do
+      let(:json) { File.read('spec/fixtures/json/embeddable.json') }
+
+      before do
+        instance.url = nil # being explicit
+        instance.save
+      end
+
+      it 'the URL is not required to be unique' do
+        new_instance = described_class.new(
+          data: { json: json },
+          exhibit: exhibit,
+          url: nil
+        )
+
+        expect(new_instance).to be_valid
+        expect(new_instance.errors).to be_empty
+      end
+    end
+
     context 'when the JSON is not parsable' do
       let(:json) { '{},' }
 


### PR DESCRIPTION
## Why was this change made?
To allow the Add Items via DLME JSON to work again.

## Was the documentation (README, API, wiki, ...) updated?
This is in the documentation, just wasn't working any longer