### PR TITLE
Update spotlight again to get browse group translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/spotlight.git
-  revision: dc906c614aef94aad78bb8b772a981e31aa3217b
+  revision: b2f35d243e652f3aac43b9465bb2018114abf936
   specs:
     blacklight-spotlight (3.0.0.rc3)
       activejob-status


### PR DESCRIPTION
## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
