### PR TITLE
Ensure gallery thumb background uses 100% width

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery.scss
@@ -10,6 +10,7 @@
       border-radius: 5px;
       height: 100%;
       padding: 1rem;
+      width: 100%;
     }
 
     .img-thumbnail {


### PR DESCRIPTION
Fixes #1202.

This PR ensures the thumbnail container in gallery view takes 100% of the available column width, so when an item's contents are relatively narrow, its thumbnail container will still be the maximum width. This ensures all containers on the page have the same width and things look nice and even.

### Before
<img width="855" alt="Screen Shot 2021-02-03 at 11 36 08 AM" src="https://user-images.githubusercontent.com/101482/106793316-8879e100-6614-11eb-9cd9-f6162f37ff91.png">

### After
<img width="855" alt="Screen Shot 2021-02-03 at 11 35 49 AM" src="https://user-images.githubusercontent.com/101482/106793343-90398580-6614-11eb-8bdc-1f67bf8ab18d.png">

