### PR TITLE
Force long continuous strings to wrap in gallery view

### DIFF
--- a/app/assets/stylesheets/blacklight_gallery.scss
+++ b/app/assets/stylesheets/blacklight_gallery.scss
@@ -27,6 +27,7 @@
 
     .document-metadata {
       margin-bottom: 0;
+      word-break: break-word;
     }
 
     dt {


### PR DESCRIPTION
Fixes #1206.

This fix will wrap long strings to prevent them from overflowing the thumbnail container. It applies to any metadata values in gallery view, but there's no real effect on normal values with words and spaces.

(In case it's relevant to anyone, the before issue isn't present in Firefox, it seems to handle the wrapping without the need for this fix. But Safari and Chrome do need it.)

### Before
<img width="474" alt="Screen Shot 2021-02-03 at 12 25 00 PM" src="https://user-images.githubusercontent.com/101482/106798210-eb6e7680-661a-11eb-961d-c73aa6ae1ff5.png">

### After
<img width="513" alt="Screen Shot 2021-02-03 at 12 13 28 PM" src="https://user-images.githubusercontent.com/101482/106798233-f3c6b180-661a-11eb-9b51-8b174407f2f4.png">

### After - no effect on normal text
<img width="513" alt="Screen Shot 2021-02-03 at 12 15 22 PM" src="https://user-images.githubusercontent.com/101482/106798265-fe814680-661a-11eb-86f5-f8608074c70c.png">

