### PR TITLE
Update Record Feedback flash message to match the Contact Us text

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -111,6 +111,7 @@ ignore_unused:
   - helpers.label.contact_form.email # Defined in Spotlight
   - helpers.label.contact_form.message # Defined in Spotlight
   - helpers.label.contact_form.name # Defined in Spotlight
+  - helpers.submit.contact_form.created # Defined in Spotlight
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -47,6 +47,9 @@ ar:
         email: البريد الالكتروني
         message: الرسالة
         name: الاسم
+    submit:
+      record_feedback:
+        created: شكراً. لقد تم إرسال ملاحظاتك واقتراحاتك.
   metadata_collapse:
     button:
       less: أقل

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,8 +43,10 @@ en:
     project_support_text: The Andrew W. Mellon Foundation
   helpers:
     submit:
+      contact_form:
+        created: Thank you. Your feedback has been submitted.
       record_feedback:
-        created: Your feedback has been submitted. Thank you. We will take care of it as soon as possible.
+        created: Thank you. Your feedback has been submitted.
   metadata_collapse:
     button:
       less: less

--- a/spec/controllers/record_feedback_controller_spec.rb
+++ b/spec/controllers/record_feedback_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RecordFeedbackController, type: :controller do
           contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', message: 'Great record!', honeypot_field_name => '' }
         }
       )
-      expect(flash[:notice]).to eq 'Your feedback has been submitted. Thank you. We will take care of it as soon as possible.'
+      expect(flash[:notice]).to eq 'Thank you. Your feedback has been submitted.'
     end
   end
 end

--- a/spec/features/record_feedback_spec.rb
+++ b/spec/features/record_feedback_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Record Feedback', type: :feature do
 
     expect(page).to have_css(
       '.flash_messages .alert-info',
-      text: 'Your feedback has been submitted. Thank you. We will take care of it as soon as possible.'
+      text: 'Thank you. Your feedback has been submitted.'
     )
   end
   # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
## Why was this change made?
To achieve synergy between the contact us and record feedback form flash messages

Closes #1208 

## Was the documentation (README, API, wiki, ...) updated?
N/A

After submitting record feedback:
<img width="1145" alt="Screen Shot 2021-02-03 at 11 17 49 AM" src="https://user-images.githubusercontent.com/96776/106798528-f1f8f000-6612-11eb-8a05-bdbdd63f6d96.png">

<img width="865" alt="Screen Shot 2021-02-03 at 11 56 24 AM" src="https://user-images.githubusercontent.com/96776/106801821-0b03a000-6617-11eb-9802-98d019e31ca8.png">
