### PR TITLE
Minify our JavaScript in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Part of #1225 

I'm seeing a reduction in production `application.js` size of:

3937039 -> ﻿1699385
