### PR TITLE
Override styling of data provider HTML within metadata values

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -334,6 +334,18 @@ body {
   transform-origin: right bottom;
 }
 
+// Override styling of data provider HTML
+// within results and show page metadata fields
+.document-metadata {
+  h1, h2, h3, h4, h5, h6 {
+    font-size: $font-size-base;
+  }
+
+  strong {
+    font-weight: normal;
+  }
+}
+
 // Overrides for mobile viewports
 @media (max-width: 767px) {
   .navbar-default .navbar-form {


### PR DESCRIPTION
Fixes #1224.

Resets styling of some HTML tags found in data provider metadata so results and item show pages don't have odd visual displays.

This PR only targets heading and `<strong>` elements; we can add other elements if and when we find other problems.

There is still often weird spacing (unnecessary blank lines) in metadata, as can be seen in the After screenshots below, but those are empty elements in the provided metadata and aren't as easily solved with CSS updates.

## Before

<img width="871" alt="before-results" src="https://user-images.githubusercontent.com/101482/107071827-8cd40480-67a2-11eb-839f-7d270ecf8222.png">

---

<img width="606" alt="before-show" src="https://user-images.githubusercontent.com/101482/107071841-92314f00-67a2-11eb-98c8-fb20c081edab.png">


## After
<img width="871" alt="after-results" src="https://user-images.githubusercontent.com/101482/107071858-98273000-67a2-11eb-94fb-45f0bd6b3d00.png">

---

<img width="606" alt="after-show" src="https://user-images.githubusercontent.com/101482/107071872-9c534d80-67a2-11eb-9d00-8363a0db59c7.png">
