### PR TITLE
Use Google Tag Manager to manage analytics

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,0 +1,10 @@
+document.addEventListener('turbolinks:load', function(event) {
+  if (typeof(dataLayer) == 'undefined') return;
+
+  var url = event.data.url;
+
+  dataLayer.push({
+    'event':'pageView',
+    'virtualUrl': url
+  });
+});

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -22,6 +22,7 @@
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
   </head>
   <body class="<%= render_body_class %>">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.analytics.gtm_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <div id="skip-link">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<%= content_tag :html, class: 'no-js', **(try(:html_tag_attributes) || {}) do %>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title><%= h(@page_title || application_name.to_s) %></title>
+    <link href="<%= current_exhibit ? spotlight.opensearch_exhibit_catalog_url(current_exhibit, format: 'xml') : main_app.opensearch_catalog_url(format: 'xml') %>" title="<%= h(@page_title || application_name.to_str) %>" type="application/opensearchdescription+xml" rel="search"/>
+    <%= favicon_link_tag 'favicon.ico' %>
+    <% if current_exhibit %>
+      <%= exhibit_stylesheet_link_tag "application" %>
+    <% else %>
+      <%= stylesheet_link_tag "application" %>
+    <% end %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+    <%= description %>
+    <%= twitter_card %>
+    <%= opengraph %>
+    <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
+  </head>
+  <body class="<%= render_body_class %>">
+    <div id="skip-link">
+      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= content_for(:skip_links) %>
+    </div>
+
+    <%= render partial: 'shared/header_navbar' %>
+    <%= render partial: 'shared/masthead' %>
+    <%= content_for?(:header_content) ? yield(:header_content) : "" %>
+
+    <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <%= content_for(:container_header) %>
+
+      <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+      <div class="row">
+        <%= content_for?(:content) ? yield(:content) : yield %>
+      </div>
+    </main>
+
+    <%= render partial: 'shared/footer' %>
+    <%= render partial: 'shared/modal' %>
+  </body>
+<% end %>

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
+    <%= render 'shared/analytics' %>
     <title><%= h(@page_title || application_name.to_s) %></title>
     <link href="<%= current_exhibit ? spotlight.opensearch_exhibit_catalog_url(current_exhibit, format: 'xml') : main_app.opensearch_catalog_url(format: 'xml') %>" title="<%= h(@page_title || application_name.to_str) %>" type="application/opensearchdescription+xml" rel="search"/>
     <%= favicon_link_tag 'favicon.ico' %>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,10 +1,9 @@
-<% if Spotlight::Engine.config.ga_web_property_id %>
-<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('create', <%= Spotlight::Engine.config.ga_web_property_id.to_json.html_safe %>, 'auto');
-ga('send', 'pageview');
-</script>
+<!-- Google Tag Manager -->
+<% if Settings.analytics.gtm_id %>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= Settings.analytics.gtm_id %>');</script>
+<!-- End Google Tag Manager -->
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -38,5 +38,4 @@
   </div>
 </footer>
 
-<%= render 'shared/analytics' %>
 <%= render 'shared/i18n_js' %>


### PR DESCRIPTION
Fixes #1220

- [x] get GTM ids for all environments
- [x] decide if we want to make a better seam for analytics upstream
- [ ] decide if we want to support GTM upstream (e.g. in `spotlight/users/analytics.js`) or make a seam for it
- [x] find out where we can actually put the GTM tags; override the whole layout just to put them in the specified places is a little annoying / a maintainability risk. 