### PR TITLE
Add begin data load job logging

### DIFF
--- a/app/jobs/fetch_resources_job.rb
+++ b/app/jobs/fetch_resources_job.rb
@@ -5,6 +5,7 @@ class FetchResourcesJob < ApplicationJob
   queue_as :default
 
   def perform(url, exhibit)
+    logger.info("Begin loading records from #{url}.")
     resp = Faraday.get(url)
 
     resources = NdjsonNormalizer.normalize(resp.body, url)


### PR DESCRIPTION
## Why was this change made?

Trying to get a better timing estimate of data loading jobs as well as show that they have started by indicating the file being loaded.

## Was the documentation (README, API, wiki, ...) updated?
