### PR TITLE
Only touch the exhibit after the whole batch is complete to avoid unnecessary thrashing

### DIFF
--- a/app/jobs/fetch_resources_job.rb
+++ b/app/jobs/fetch_resources_job.rb
@@ -13,6 +13,8 @@ class FetchResourcesJob < ApplicationJob
       create_or_update_resource(item, exhibit, index, url)
     end
 
+    exhibit.touch # rubocop:disable Rails/SkipsModelValidations
+
     logger.info("#{resources.count} records were created from #{url}.")
   end
 
@@ -25,6 +27,6 @@ class FetchResourcesJob < ApplicationJob
     raise "Resource #{index + 1} in #{url} is not valid: #{resource.errors.full_messages.to_sentence}" unless resource.valid?
 
     resource.save
-    resource.reindex
+    resource.reindex(touch: false)
   end
 end

--- a/spec/jobs/fetch_resources_job_spec.rb
+++ b/spec/jobs/fetch_resources_job_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe FetchResourcesJob, type: :job do
 
   context 'when the record is unique' do
     it 'adds the record' do
+      allow(exhibit).to receive(:touch)
       expect { described_class.perform_now(url, exhibit) }.to change(DlmeJson, :count).by(1)
       expect(Faraday).to have_received(:get).with(url)
+      expect(exhibit).to have_received(:touch).once
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Touching the exhibit busts caches (among other things); instead, we should wait until the end of the batch.
