### PR TITLE
Persistent timeout

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,6 +12,7 @@ threads min_threads_count, max_threads_count
 # terminating a worker in development environments.
 #
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+persistent_timeout 75
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #


### PR DESCRIPTION
## Why was this change made?

This is apparently a thing people do when running puma in ECS 🤷‍♂️ 

