### PR TITLE
Update master to main in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,25 +214,25 @@ workflows:
     - test:
         filters:
           branches:
-            ignore: master
+            ignore: main
   build:
     jobs:
     - build-image:
         filters:
           branches:
-            only: master
+            only: main
     - publish-latest:
         requires:
         - build-image
         filters:
           branches:
-            only: master
+            only: main
     - update_ecs:
         requires:
         - publish-latest
         filters:
           branches:
-            only: master
+            only: main
   build-tags:
     jobs:
     - build-image:


### PR DESCRIPTION
## Why was this change made?

Catching up on moving to `main` as the default branch.

## Was the documentation (README, API, wiki, ...) updated?
