### PR TITLE
Have DLME thumbnails completely skip the asset pipeline because they …

### DIFF
--- a/app/presenters/dlme_thumbnail_presenter.rb
+++ b/app/presenters/dlme_thumbnail_presenter.rb
@@ -11,7 +11,7 @@ class DlmeThumbnailPresenter < Blacklight::ThumbnailPresenter
     }
 
     injected_options[:class] = 'img-thumbnail' unless view_context.controller.action_name == 'show'
-    super(image_options.merge(injected_options), url_options)
+    super(image_options.merge(injected_options), url_options.reverse_merge(skip_pipeline: true))
   end
 
   private


### PR DESCRIPTION
…should always be external urls

## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
