### PR TITLE
Update localstack in docker-compose and README as ports changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,18 @@ Configure AWS CLI to use localstack-run endpoints:
 
 ```
 AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sns \
-    --endpoint-url=http://localhost:4575 create-topic \
+    --endpoint-url=http://localhost:4566 create-topic \
     --region us-east-1 \
     --name dlme-transform
 
 AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws s3api \
-    --endpoint-url=http://localhost:4572 create-bucket \
+    --endpoint-url=http://localhost:4566 create-bucket \
     --region us-east-1 \
     --bucket dlme-transform
 
 AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sns \
-    --endpoint-url=http://localhost:4575 subscribe \
-    --topic-arn arn:aws:sns:us-east-1:123456789012:dlme-transform \
+    --endpoint-url=http://localhost:4566 subscribe \
+    --topic-arn arn:aws:sns:us-east-1:000000000000:dlme-transform \
     --protocol http \
     --region us-east-1 \
     --notification-endpoint http://app:3000/transform_result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,9 +83,7 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "4575:4575"
-      - "4572:4572"
-      - "8080:8080"
+      - "4566:4566"
     environment:
       - SERVICES=sns,s3
       - DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
## Why was this change made?

At some point in the recent past (https://github.com/localstack/localstack/issues/3080) the individual ports used by each localstack service is now gated through an edge service port.

This fixes docker-compose.yml and README instructions around that change.

BEFORE:

```
❯ AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sns \
    --endpoint-url=http://localhost:4575 create-topic \
    --region us-east-1 \
    --name dlme-transform

Connection was closed before we received a valid response from endpoint URL: "http://localhost:4575/".
```

AFTER:

```
❯ AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sns \
    --endpoint-url=http://localhost:4566 create-topic \
    --region us-east-1 \
    --name dlme-transform

{
    "TopicArn": "arn:aws:sns:us-east-1:000000000000:dlme-transform"
}
```
## Was the documentation (README, API, wiki, ...) updated?
