### PR TITLE
fix transform command in local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ docker run --rm -e S3_BUCKET=dlme-transform \
                 -e AWS_ACCESS_KEY_ID=999999 \
                 -e AWS_SECRET_ACCESS_KEY=1231 \
                 -e AWS_DEFAULT_REGION=us-east-1 \
-                -e SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:dlme-transform \
-                -e SNS_ENDPOINT_URL=http://localhost:4575 \
-                -e S3_ENDPOINT_URL=http://localhost:4572 \
-                -e S3_BASE_URL=http://localstack:4572 \
+                -e SNS_TOPIC_ARN=arn:aws:sns:us-east-1:000000000000:dlme-transform \
+                -e SNS_ENDPOINT_URL=http://localhost:4566 \
+                -e S3_ENDPOINT_URL=http://localhost:4566 \
+                -e S3_BASE_URL=http://localstack:4566 \
                 -e SKIP_FETCH_DATA=true \
                 -v $(pwd)/../dlme-transform:/opt/traject \
                 -v $(pwd)/../dlme-metadata:/opt/traject/data \


### PR DESCRIPTION
## Why was this change made?

follow on to https://github.com/sul-dlss/dlme/pull/1304

i found that when i ran the local transform as it was, i got `upload failed: output/output-ae7331e3-ef91-43ff-826a-1dcbc1c2c60f.ndjson to s3://dlme-transform/output-ae7331e3-ef91-43ff-826a-1dcbc1c2c60f.ndjson Could not connect to the endpoint URL: "http://localhost:4572/dlme-transform/output-ae7331e3-ef91-43ff-826a-1dcbc1c2c60f.ndjson"`.  with this change, i got `upload: output/output-e2244b2e-88d2-41fd-b9bb-7e0deec2b2a1.ndjson to s3://dlme-transform/output-e2244b2e-88d2-41fd-b9bb-7e0deec2b2a1.ndjson` and no error messages.

## Was the documentation (README, API, wiki, ...) updated?

yup