### PR TITLE
Set the host binding for local docker app

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Allow docker networks to access application by hostname in development
+  config.hosts.clear
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       # For development
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_ENV=development
-      - HOST=0.0.0.0
       - SETTINGS__FEATURE_FLAGS__ALLOW_JSON_UPLOAD=true
     image: 'suldlss/dlme:latest'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     # For running in dev
     volumes:
       - ".:/opt/"
-    command: bundle exec rails server
+    command: bundle exec rails server -b 0.0.0.0
   postgres:
     image: postgres
     ports:


### PR DESCRIPTION
## Why was this change made?

Adding the binding to the rails server command allows docker-compose to be used for local development.

Fixes #831  - and allows development with all components of the application stack

## Was the documentation (README, API, wiki, ...) updated?
