### PR TITLE
Remove real URL from test so timeouts do not break build

### DIFF
--- a/spec/fixtures/json/iiif-single-image.json
+++ b/spec/fixtures/json/iiif-single-image.json
@@ -16,9 +16,6 @@
       "service_implements": "http://iiif.io/api/image/2/level2.json"
     }]
   },
-  "agg_preview": {
-    "wr_id": "http://libimages.princeton.edu/loris2/pudl0100%2Fposters%2Feg1_0095%2F00000001.jp2/full/200,/0/default.jpg"
-  },
   "agg_provider": "Princeton University",
   "agg_provider_country": "United States of America",
   "cho_contributor": ["فاتن حمامة", "محمود ياسين", "فريد شوقي", "بركات"],

--- a/spec/resource_builders/dlme_json_resource_builder_spec.rb
+++ b/spec/resource_builders/dlme_json_resource_builder_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe DlmeJsonResourceBuilder do
         'cho_type_ssim' => 'Posters',
         :id => 'princeton_rj4305881',
         'agg_is_shown_at.wr_id_ssim' => 'http://arks.princeton.edu/ark:/88435/rj4305881',
-        'agg_preview.wr_id_ssim' => 'http://libimages.princeton.edu/loris2/pudl0100%2Fposters%2Feg1_0095%2F00000001.jp2/full/200,/0/default.jpg',
         'agg_is_shown_by.wr_id_ssim' => 'https://libimages.princeton.edu/loris2/pudl0100%2Fposters%2Feg1_0095%2F00000001.jp2/full/634,/0/default.jpg',
         'agg_is_shown_by.wr_format_ssim' => 'image/jpeg' }
     end


### PR DESCRIPTION
## Why was this change made?

This removes the real princeton URL to a thumbnail from a iiif fixture. If the thumbnail is unreachable, the timeout breaks tests and builds.

```
2021-08-12 01:55:39 +0000 Rack app ("GET /image_proxyurl=http%3A%2F%2Flibimages.princeton.edu%2Floris2%2Fpudl0100%252Fposters%252Feg1_0095%252F00000001.jp2%2Ffull%2F200%2C%2F0%2Fdefault.jpg" - (127.0.0.1)): #<Rack::Timeout::RequestTimeoutError: Request ran for longer than 60000ms >
F2021-08-12 01:56:40 +0000 Rack app ("GET /image_proxyurl=http%3A%2F%2Flibimages.princeton.edu%2Floris2%2Fpudl0100%252Fposters%252Feg1_0095%252F00000001.jp2%2Ffull%2F200%2C%2F0%2Fdefault.jpg" - (127.0.0.1)): #<Rack::Timeout::RequestTimeoutError: Request ran for longer than 60000ms >
F.2021-08-12 01:57:43 +0000 Rack app ("GET /image_proxyurl=http%3A%2F%2Flibimages.princeton.edu%2Floris2%2Fpudl0100%252Fposters%252Feg1_0095%252F00000001.jp2%2Ffull%2F200%2C%2F0%2Fdefault.jpg" - (127.0.0.1)): #<Rack::Timeout::RequestTimeoutError: Request ran for longer than 60000ms >
F
```

## Was the documentation (README, API, wiki, ...) updated?
