### PR TITLE
Add a simple rake task for purging transform results

### DIFF
--- a/lib/tasks/transform.rake
+++ b/lib/tasks/transform.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :transform do
+  desc 'Purge transform results'
+  task purge_results: :environment do
+    TransformResult.destroy_all
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This is a small rake task to clear out existing transform results. This will be run as a one off ECS task when needed so there is no need to expose this in the UI.

## Was the documentation (README, API, wiki, ...) updated?
