### PR TITLE
Add a rake task and invoke script to trigger resources indexing from …

### DIFF
--- a/docker/invoke_fetch_s3.sh
+++ b/docker/invoke_fetch_s3.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+
+echo "Fetching resources from: ${S3_FETCH_URL}"
+
+bundle exec rake fetch:s3[$S3_FETCH_URL]

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :fetch do
+  desc 'Fetch S3 resources for indexing'
+  task :s3, [:url] => [:environment] do |_t, args|
+    dlme_exhibit = Spotlight::Exhibit.find_by(title: 'dlme')
+    FetchResourcesJob.perform_now args[:url], dlme_exhibit
+  end
+end


### PR DESCRIPTION
…an ECS task

## Why was this change made?

This allows resources indexing to be automated. By exposing the job in a rake task and an invoke script, this can be triggered from airflow during ETL automation.

## Was the documentation (README, API, wiki, ...) updated?
