### PR TITLE
Fix the query for the dlme stage cluster arn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
             aws configure set output json
             aws configure list # Show confirmation of config
             task_arn=$(aws ecs list-task-definitions --family-prefix spotlight --region us-west-2 --sort DESC --max-items 1 | jq --raw-output --exit-status '.taskDefinitionArns[]')
-            cluster_arn=$(aws ecs list-clusters --region us-west-2 | jq --raw-output --exit-status '.clusterArns[] | select(contains(":cluster/dlme"))')
+            cluster_arn=$(aws ecs list-clusters --region us-west-2 | jq --raw-output --exit-status '.clusterArns[] | select(test("arn:aws:ecs:us-west-2:[0-9]+:cluster/dlme$"))')
             # echo -n "task_arn=$task_arn\ncluster_arn=$cluster_arn\n"
             aws ecs update-service --service spotlight --region us-west-2 --cluster $cluster_arn --task-definition $task_arn --force-new-deployment
 


### PR DESCRIPTION
## Why was this change made?

I found an issue with the staging query for the cluster. The current case returns both `dlme` and `dlme-uat` which causes an error when trying to update the tasks for stage. This limits the cluster arn query to just `dlme`.

## Was the documentation (README, API, wiki, ...) updated?
