### PR TITLE
Remove restrictive exhibit selection

### DIFF
--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -3,7 +3,7 @@
 namespace :fetch do
   desc 'Fetch S3 resources for indexing'
   task :s3, [:url] => [:environment] do |_t, args|
-    dlme_exhibit = Spotlight::Exhibit.find_by(title: 'dlme')
+    dlme_exhibit = Spotlight::Exhibit.first
     FetchResourcesJob.perform_now args[:url], dlme_exhibit
   end
 end


### PR DESCRIPTION
## Why was this change made?

Selection by name here is problematic for DLME as title can be changed between local dev and deployed environments. DLME uses a single exhibit, so this task can safely use the first one available.

## Was the documentation (README, API, wiki, ...) updated?
