### PR TITLE
Use find_or_initialize_by instead of find_or_create_by for transform_…

### DIFF
--- a/app/controllers/transform_results_controller.rb
+++ b/app/controllers/transform_results_controller.rb
@@ -12,7 +12,7 @@ class TransformResultsController < ApplicationController
 
   # This is invoked by SNS HTTP subscription
   def create
-    transform_result = TransformResult.find_or_create_by(notification_params)
+    transform_result = TransformResult.find_or_initialize_by(notification_params)
     transform_result.update(build_notification)
     head :created
   end

--- a/spec/requests/transform_result_spec.rb
+++ b/spec/requests/transform_result_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe 'transform results', type: :request do
     let(:transform_result) { class_double('TransformResult') }
 
     before do
-      allow(TransformResult).to receive(:find_or_create_by).and_return(transform_result)
+      allow(TransformResult).to receive(:find_or_initialize_by).and_return(transform_result)
       allow(transform_result).to receive(:update)
     end
 
     it 'creates the TransformResult' do
       post '/transform_result', params: msg, headers: headers
-      expect(TransformResult).to have_received(:find_or_create_by).with(url: 'http://localstack:4572/dlme-transform/output-20190222190423.ndjson',
-                                                                        data_path: 'stanford/maps/data/kj751hs0595.mods')
+      expect(TransformResult).to have_received(:find_or_initialize_by).with(url: 'http://localstack:4572/dlme-transform/output-20190222190423.ndjson',
+                                                                            data_path: 'stanford/maps/data/kj751hs0595.mods')
       expect(transform_result).to have_received(:update).with(success: true,
                                                               records: 1,
                                                               timestamp: DateTime.iso8601('2019-02-22T19:04:24+00:00'),


### PR DESCRIPTION
…results

Fixes #1340 

`find_or_create_by` throws an error if there are any null values for `null: false` fields. `find_or_initialize_by` uses `new` instead of `create` to avoid the error and allow the update command to do the commit and set the remaining fields.

## Why was this change made?


## Was the documentation (README, API, wiki, ...) updated?
