### PR TITLE
Update to non legacy circlci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ executors:
       WEBAPP_IMAGE_NAME: suldlss/dlme
       WORKER_IMAGE_NAME: suldlss/dlme-worker
     docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/base
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.2-node-browsers
+    - image: cimg/ruby:2.7-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3
@@ -183,7 +183,7 @@ jobs:
 
   update_ecs_dev:
     docker: # NOT the default
-      - image: circleci/python:3.7-stretch-node-browsers
+      - image: cimg/python:3.7-browsers
     steps:
       - run: sudo pip install awscli
       - run:
@@ -212,7 +212,7 @@ jobs:
 
   update_ecs_uat:
     docker: # NOT the default
-      - image: circleci/python:3.7-stretch-node-browsers
+      - image: cimg/python:3.7-browsers
     steps:
       - run: sudo pip install awscli
       - run:
@@ -241,7 +241,7 @@ jobs:
 
   update_ecs_stage:
     docker: # NOT the default
-      - image: circleci/python:3.7-stretch-node-browsers
+      - image: cimg/python:3.7-browsers
     steps:
       - run: sudo pip install awscli
       - run:
@@ -270,7 +270,7 @@ jobs:
 
   update_ecs_prod:
     docker: # NOT the default
-      - image: circleci/python:3.7-stretch-node-browsers
+      - image: cimg/python:3.7-browsers
     steps:
       - run: sudo pip install awscli
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: cimg/ruby:2.7-node
+    - image: circleci/ruby:2.7.2-node-browsers
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
       WEBAPP_IMAGE_NAME: suldlss/dlme
       WORKER_IMAGE_NAME: suldlss/dlme-worker
     docker:
-    - image: cimg/base
+    - image: cimg/base:stable
 jobs:
   test:
     docker:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.13.0-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -693,6 +695,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-sns


### PR DESCRIPTION
## Why was this change made?

Maintenance to update circleci images from `circleci` prefixes that were deprecated on 12/31.

## Was the documentation (README, API, wiki, ...) updated?
