### PR TITLE
Disable pretty format extensions for catalog routes; fixes #1344

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
     concern :exportable, Blacklight::Routes::Exportable.new
 
-    resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog', id: %r{.+} do
+    resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog', id: %r{.+}, format: false do
       concerns :exportable
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes a regression with #473, which allowed for document ids that are indistinguishable from format extensions 

## Was the documentation (README, API, wiki, ...) updated?
