### PR TITLE
Special handling for locale aware provider_facet_field. Fixes #1349

### DIFF
--- a/app/models/statistics_dashboard.rb
+++ b/app/models/statistics_dashboard.rb
@@ -201,6 +201,10 @@ class StatisticsDashboard
       StatisticsDashboard.locale_aware_field(provider_field_key)
     end
 
+    def provider_facet_field
+      "#{provider_field_key}_#{I18n.locale}"
+    end
+
     # Represents each row in the Contributors table
     class Institution
       attr_reader :facet

--- a/app/views/statistics/_contributors.html.erb
+++ b/app/views/statistics/_contributors.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% contributors.institutions.each do |institution| %>
       <tr>
-        <td><%= link_to institution.name, path_for_facet(contributors.provider_field, institution.name), class: 'value' %></td>
+        <td><%= link_to institution.name, path_for_facet(contributors.provider_facet_field, institution.name), class: 'value' %></td>
         <td class="value"><%= institution.countries.join(', ') %></td>
         <td class="text-right"><%= number_with_delimiter(institution.collection_count) %></td>
         <td class="text-right"><%= number_with_delimiter(institution.item_count) %></td>

--- a/spec/models/statistics_dashboard_spec.rb
+++ b/spec/models/statistics_dashboard_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe StatisticsDashboard do
       expect(contributors.provider_field).to eq 'agg_provider.ar-Arab_ssim'
     end
 
+    it 'has a locale aware provider_facet_field accessor' do
+      expect(contributors.provider_facet_field).to eq 'agg_provider_en'
+
+      allow(I18n).to receive(:locale).and_return('ar')
+
+      expect(contributors.provider_facet_field).to eq 'agg_provider_ar'
+    end
+
     describe '#institutions' do
       let(:institutions) { contributors.institutions }
 


### PR DESCRIPTION
## Why was this change made?

The `agg_data_provider_*` and `agg_provider_*` fields do not follow the same pattern as other locale aware fields. This PR adds handling for these fields and fixes the click to search by institution feature on the statistics page.
