### PR TITLE
Tag and push new docker images with the sha1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,12 @@ jobs:
         name: Publish Docker Image to Docker Hub
         command: |
           echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          docker tag $WEBAPP_IMAGE_NAME:latest $WEBAPP_IMAGE_NAME:$CIRCLE_SHA1
+          docker tag $WORKER_IMAGE_NAME:latest $WORKER_IMAGE_NAME:$CIRCLE_SHA1
           docker push $WEBAPP_IMAGE_NAME:latest
           docker push $WORKER_IMAGE_NAME:latest
+          docker push $WEBAPP_IMAGE_NAME:$CIRCLE_SHA1
+          docker push $WORKER_IMAGE_NAME:$CIRCLE_SHA1
 
   publish-tag:
     executor: docker-publisher


### PR DESCRIPTION
Pushing the image tagged with the SHA1 seems to be conventional practice. If nothing else, this'll let us take a look at what's changed over time 🤷‍♂️ 