### PR TITLE
Export documents as ndjson

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -9,10 +9,16 @@ class SolrDocument
   def initialize(*args)
     super
     will_export_as(:ir)
+    will_export_as(:ndjson)
   end
 
   def export_as_ir
     fetch('__raw_resource_json_ss', '')
+  end
+
+  # Reparse the IR and reformat it to a single line
+  def export_as_ndjson
+    JSON.fast_generate(JSON.parse(export_as_ir))
   end
 
   # overriding the upstream method with our own that knows

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,3 +4,4 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register "application/ir+json", :ir
+Mime::Type.register "application/x-ndjson", :ndjson


### PR DESCRIPTION
Fixes #1467.

This should allow us to slurp search results and single documents into a development environment without too much fuss by tacking on the format (e.g. https://dev.dlmenetwork.org/library/catalog.ndjson, or with any combination of search parameters).


