### PR TITLE
Only display 1 line of title in breadcrumb

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -373,3 +373,8 @@ body {
 #document h1[itemprop="name"] {
   @include truncate_title(2);
 }
+
+// Don't show multiple title lines in breadcrumb
+.breadcrumb-item > span > :not(:first-child) {
+  display: none;
+}


### PR DESCRIPTION
Fixes #1497 

I removed this styling tweak from the upstream Spotlight PR and brought it down to DLME, because as @cbeer pointed out, it's very specific to DLME.

Before:
![Screen Shot 2022-02-16 at 10 51 24](https://user-images.githubusercontent.com/1328900/155437622-5e503ce8-0198-4b88-a09c-0eabb6fadd2b.png)

After:
![Screen Shot 2022-02-23 at 17 03 47](https://user-images.githubusercontent.com/1328900/155437631-931fb558-b4f4-4e17-84f8-16dc12a33f05.png)

