### PR TITLE
Add Mirador Image Tools plugin

### DIFF
--- a/app/javascript/packs/mirador.js
+++ b/app/javascript/packs/mirador.js
@@ -21,10 +21,12 @@ import 'url-polyfill/url-polyfill';
 import 'unfetch/polyfill';
 
 import Mirador from 'mirador/dist/es/src/index.js';
+import miradorImageToolsPlugin from 'mirador-image-tools/es/plugins/miradorImageToolsPlugin.js';
+
 const manifestUrl = document.querySelector('#m3').dataset.iiifManifest;
 const htmlAttributes = document.querySelector('html').attributes;
 
-Mirador.viewer({
+const config = {
   id: 'm3',
   language: htmlAttributes.lang.nodeValue,
   theme: {
@@ -52,7 +54,14 @@ Mirador.viewer({
   workspaceControlPanel: {
     enabled: false,
   },
-  windows: [
-    {loadedManifest: manifestUrl}
-  ]
-})
+  windows: [{
+    imageToolsEnabled: true,
+    loadedManifest: manifestUrl
+  }]
+}
+
+const plugins = [
+  ...miradorImageToolsPlugin
+];
+
+Mirador.viewer(config, plugins)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "^5.4.3",
     "core-js": "^3.4.8",
     "mirador": "^3.0.0-beta.10",
+    "mirador-image-tools": "^0.11.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/spec/features/mirador_viewer_spec.rb
+++ b/spec/features/mirador_viewer_spec.rb
@@ -24,4 +24,9 @@ RSpec.describe 'Mirador viewer', type: :feature do
     expect(page).to have_css('#m3')
     expect(page).to have_css('.mirador-viewer')
   end
+
+  it 'enables Mirador Image Tools plugin', js: true do
+    visit spotlight.exhibit_solr_document_path(exhibit_id: exhibit.slug, id: '36ebabd9-4d62-4d8e-8e7b-1afd048e872e')
+    expect(page).to have_css('div[class*=MiradorImageTools]')
+  end
 end


### PR DESCRIPTION
Fixes #1350 

- Adds plugin to package.json
- Enables plugin in config
- Checks for plugin existence in spec