### PR TITLE
Disable lograge compact logging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,5 +119,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.lograge.enabled = true
+  config.lograge.enabled = false
 end


### PR DESCRIPTION
It removes too much information and makes the logs harder to investigate.