### PR TITLE
Undo rake debugging trace that is no longer needed

### DIFF
--- a/docker/invoke_fetch_s3.sh
+++ b/docker/invoke_fetch_s3.sh
@@ -5,4 +5,4 @@
 echo "Fetching resources from: ${S3_FETCH_URL}"
 
 # Add additional logging output on rake for debugging
-bundle exec honeybadger exec rake resources:fetch[$S3_FETCH_URL] --trace
+bundle exec honeybadger exec rake resources:fetch[$S3_FETCH_URL]


### PR DESCRIPTION
This was useful to debug triggering indexing from airflow but is not necessary and may overly fill the logs...