### PR TITLE
Pin i18n-js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,5 +112,5 @@ gem 'webpacker', '~> 5.0'
 
 gem 'cache_with_locale'
 
-gem 'i18n-js'
+gem 'i18n-js', '< 4' # v4 was a complete rewrite; will take some work to update
 gem 'i18n-tasks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,6 @@ GEM
     friendly_id (5.4.2)
       activerecord (>= 4.0.0)
     github-markup (4.0.1)
-    glob (0.2.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     guard (2.18.0)
@@ -764,7 +763,7 @@ DEPENDENCIES
   guard-rspec
   honeybadger
   http
-  i18n-js
+  i18n-js (< 4)
   i18n-tasks
   iiif-presentation (~> 1.0)
   jbuilder (~> 2.7)


### PR DESCRIPTION
i18n-js was added in:
https://github.com/sul-dlss/dlme/pull/902/files

to support changing the date picker translations. 

I18n-js v4 was a ground-up rewrite, and will take some work to (re)install. Notably, the asset pipeline "magic" has been replaced by an explicit "export" step + CLI tool. We'll have to figure out how to add that step for dev + production builds. This seems like an excessive amount of work to export 4 keys 😬 .
