### PR TITLE
Restore clobbered link to bulk updates on exhibit dashboard

### DIFF
--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -19,4 +19,7 @@
   <% if (can? :manage, current_exhibit.translations.first_or_initialize) && current_exhibit.languages.any? %>
     <%= nav_link t(:'spotlight.curation.sidebar.translations'), spotlight.edit_exhibit_translations_path(current_exhibit), 'data-no-turbolink' => true %>
   <% end %>
+  <% if can? :bulk_update, current_exhibit %>
+    <%= nav_link t(:'spotlight.curation.sidebar.bulk_updates'), spotlight.edit_exhibit_bulk_updates_path(current_exhibit), 'data-no-turbolink' => true %>
+  <% end %>
 </ul>


### PR DESCRIPTION
This restores the bulk update link to the exhibit sidebar that is clobbered from the upstream spotlight code (https://github.com/projectblacklight/spotlight/blob/main/app/views/spotlight/shared/_curation_sidebar.html.erb)