### PR TITLE
Revert "Upgrade to sidekiq 7 and redis 5"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 5.0'
+gem 'redis', '~> 4.5.1' # 4.6.0 spews deprecation warnings out of sidekiq
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -68,7 +68,8 @@ end
 group :production do
   gem 'carrierwave-aws'
   gem 'pg'
-  gem 'sidekiq', '~> 7.0'
+  # Set sidekiq to < 7 until we move DLME on premise and update redis to >= 6
+  gem 'sidekiq', '< 7'
 end
 
 gem 'aws-sdk-sns'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,10 +531,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    redis (5.0.6)
-      redis-client (>= 0.9.0)
-    redis-client (0.12.1)
-      connection_pool
+    redis (4.5.1)
     regexp_parser (2.6.2)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -637,11 +634,10 @@ GEM
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
     shellany (0.0.1)
-    sidekiq (7.0.3)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.11.0)
+    sidekiq (6.5.8)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -778,7 +774,7 @@ DEPENDENCIES
   rails (~> 7.0)
   rails-controller-testing
   rails_autolink
-  redis (~> 5.0)
+  redis (~> 4.5.1)
   riiif (~> 2.0)
   rsolr (>= 1.0)
   rspec-rails
@@ -790,7 +786,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   shakapacker (~> 6.4)
-  sidekiq (~> 7.0)
+  sidekiq (< 7)
   simplecov (~> 0.21)
   sitemap_generator
   slowpoke (~> 0.4)


### PR DESCRIPTION
This reverts commit 5289fb70e7b57f3d58601f41395b9a5dfc70fc8a.

Redis is still on version 5 in AWS so we cannot upgrade to Sidekiq 7 until we do one of:

- stop auto-deploying to AWS
- upgrade redis in AWS to version 6+ (does not seem worth it since we're moving everything on premises)

This is currently preventing any indexing activity:

```
[ActiveJob] Failed enqueuing AddResourcesJob to Sidekiq(dlme_production_default): RedisClient::UnsupportedServer (redis-client requires Redis 6+ with HELLO command available (redis://dlme.njlkho.0001.usw2.cache.amazonaws.com:6379/1))
```