### PR TITLE
Update database config for on-prem usage

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,18 +10,8 @@ default: &default
   timeout: 5000
 
 development:
-  <% if ENV.key? 'RDS_HOSTNAME' %>
-    adapter: postgresql
-    encoding: unicode
-    database: "<%= ENV['RDS_DB_NAME'] %>"
-    username: "<%= ENV['RDS_USERNAME'] %>"
-    password: "<%= ENV['RDS_PASSWORD'] %>"
-    host: "<%= ENV['RDS_HOSTNAME'] %>"
-    port: "<%= ENV['RDS_PORT'] %>"
-  <% else %>
     <<: *default
     database: db/development.sqlite3
-  <% end %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -29,13 +19,3 @@ development:
 test:
   <<: *default
   database: db/test.sqlite3
-
-production:
-  adapter: postgresql
-  encoding: unicode
-  database: "<%= ENV['RDS_DB_NAME'] %>"
-  username: "<%= ENV['RDS_USERNAME'] %>"
-  password: "<%= ENV['RDS_PASSWORD'] %>"
-  host: "<%= ENV['RDS_HOSTNAME'] %>"
-  port: "<%= ENV['RDS_PORT'] %>"
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 25 } %>


### PR DESCRIPTION
We don't need the production environment as that is provided by puppet (`capistrano_db_yaml: true`)