### PR TITLE
Add redis check to okcomputer

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -2,4 +2,4 @@ OkComputer.mount_at = 'status'
 
 OkComputer::Registry.register 'solr', OkComputer::SolrCheck.new(Blacklight.default_index.connection.uri.to_s.sub(/\/$/, ''))
 
-OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new(env: 'GIT_INFO')
+OKComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('SIDEKIQ_REDIS_URL', 'redis://localhost:6379/'))


### PR DESCRIPTION
Also removes the git version check, which we added for additional
visibility into the built docker images. No longer necessary for
non-docker on-prem deployments.

See #1607
