### PR TITLE
Removing S3 handling

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,9 +1,0 @@
-if Settings.s3.upload_bucket
-  CarrierWave.configure do |config|
-    config.storage = :aws
-    config.aws_bucket = Settings.s3.upload_bucket
-    config.aws_acl = 'bucket-owner-full-control'
-  end
-
-  Spotlight::Engine.config.uploader_storage = :aws
-end

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,15 +1,7 @@
 ActiveSupport::Reloader.to_prepare do
-  if Settings.s3.upload_bucket
-    Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
-    Riiif::Image.file_resolver.id_to_uri = lambda do |id|
-      aws_file = Spotlight::FeaturedImage.find(id).image.file
-      raise Riiif::ImageNotFoundError, "unable to find file for #{id}" if aws_file.nil?
-
-      aws_file.file.presigned_url(:get)
-    end
-  else
-    Riiif::Image.file_resolver = Spotlight::CarrierwaveFileResolver.new
-  end
+  
+  Riiif::Image.file_resolver = Spotlight::CarrierwaveFileResolver.new
+  
   # Riiif::Image.authorization_service = IIIFAuthorizationService
 
   # Riiif.not_found_image = 'app/assets/images/us_404.svg'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,8 +21,6 @@ cache_period: <%= 12.hours %>
 contact:
   email: ~
 
-s3:
-  upload_bucket: ~
 
 allow_robots: false
 


### PR DESCRIPTION
What this pull request does (#1659 ):

- With image storage being moved off S3 to on premise, we no longer need S3 handling for images.  
- Settings.yml no longer requires an S3 bucket key
- The file "carrierwave.rb" can be removed, since the entirety of that code handles the condition for the S3 bucket.
- When the S3 handling is removed from riiif.rb, the file matches the original Spotlight file https://github.com/projectblacklight/spotlight/blob/main/lib/generators/spotlight/templates/config/initializers/riiif.rb .  Removing the file results in an error (on my local machine) so the file remains although, after the removal of S3 specific handling, the code is identical to the one in Spotlight. (Please feel free to let me know if, instead, the code should work without the riiif file included at all in the DLME layer since it's already in the Spotlight code.)