### PR TITLE
Disable the queue name prefix

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter     = :sidekiq
-  config.active_job.queue_name_prefix = "#{ENV['ACTIVE_JOB_QUEUE_PREFIX']}_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "#{ENV['ACTIVE_JOB_QUEUE_PREFIX']}_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
This restores the Rails defaults: https://github.com/rails/rails/blob/fad9050d80cb4d2d7c482311832724558bbfbbc2/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L81