### PR TITLE
Ensure document_presenter#header returns a string

### DIFF
--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -8,5 +8,6 @@ ActiveSupport::Reloader.to_prepare do
                                                 BidiWrap,
                                                 Paragraph,
                                                 Join,
-                                                Collapse]
+                                                Collapse,
+                                                Blacklight::Rendering::Join]
 end


### PR DESCRIPTION
The pipeline was configured to return an array. It must return a String to conform with the interface in DocumentPresenter#header Fixes #1705