### PR TITLE
Defer config until script has loaded

### DIFF
--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -20,7 +20,7 @@
     <%= opengraph %>
     <%= javascript_importmap_tags 'entry' %>
     <%= javascript_include_tag "application", defer: true %>
-    <%= javascript_tag "Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}'" %>
+    <%= javascript_tag "window.addEventListener('load', () => Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}')" %>
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
   </head>
   <body class="<%= render_body_class %>">

--- a/app/views/shared/_i18n_js.html.erb
+++ b/app/views/shared/_i18n_js.html.erb
@@ -1,4 +1,6 @@
 <%= javascript_tag do %>
-  I18n.defaultLocale = "<%= I18n.default_locale %>";
-  I18n.locale = "<%= I18n.locale %>";
+  window.addEventListener('load', () => {
+    I18n.defaultLocale = "<%= I18n.default_locale %>";
+    I18n.locale = "<%= I18n.locale %>";
+  })
 <% end %>


### PR DESCRIPTION
This avoids a "Uncaught ReferenceError: Spotlight is not defined"