### PR TITLE
Adjust positioning of header menu on mobile

### DIFF
--- a/app/assets/stylesheets/dlme.scss
+++ b/app/assets/stylesheets/dlme.scss
@@ -209,13 +209,10 @@ body {
   margin-top: 1rem;
 }
 
-// Hide the site title in the masthead, because we render it in the navbar
-.masthead .site-title {
+// Hide the site title text in the masthead, because we render it in the navbar.
+// The element still takes up space so spotlight's header is the right size
+.masthead .site-title-container {
   visibility: hidden;
-
-  + small {
-    visibility: hidden;
-  }
 }
 
 .exhibit-navbar {
@@ -387,13 +384,9 @@ body {
     border: 0;
   }
 
-  // Hide the masthead title on mobile, because we render it in the navbar
+  // Adjust sizing of (hidden) title container on mobile, used as spacer
   .masthead .site-title-container {
-    display: none;
-  }
-
-  .topbar + .masthead {
-    padding-top: 4rem;  // height of navbar on mobile
+    height: 3.5rem;
   }
 }
 


### PR DESCRIPTION
Before (masthead image doesn't go under header; menu is too long):
![Screen Shot 2023-03-03 at 13 45 14](https://user-images.githubusercontent.com/4924494/222835677-9ec9af31-fadc-4c40-a91d-54867ce6547c.png)

After:
![Screen Shot 2023-03-03 at 13 44 43](https://user-images.githubusercontent.com/4924494/222835735-bc8611c0-d47f-4d9c-a735-fea393ddd735.png)

