### PR TITLE
Use search_facet_path directly instead of deprecated method

### DIFF
--- a/app/components/multilingual_date_range_component.rb
+++ b/app/components/multilingual_date_range_component.rb
@@ -20,8 +20,8 @@ class MultilingualDateRangeComponent < ViewComponent::Base
   def date_range_switcher_query_paths
     other_field_name = facet_configuration[:configured_range_fields].find { |f| f[:field] != field_name }[:field]
     {
-      other_field_name => helpers.range_limit_panel_url(id: other_field_name, range: nil, locale: :en),
-      field_name => helpers.range_limit_panel_url(id: field_name)
+      other_field_name => helpers.search_facet_path(id: other_field_name),
+      field_name => helpers.search_facet_path(id: field_name)
     }
   end
 


### PR DESCRIPTION
Closes #1702 

The other option key/values passed to range_limit_panel_url weren't being used so I've dropped them, see: https://github.com/projectblacklight/blacklight_range_limit/commit/32d073f9a8d8427b047f8bcad2cab76e25ad1636#diff-e1b174fbb4b0c2595fdb35078674ca8d1796dca15eef88ec137981003d315d0fR10