### PR TITLE
Use Google Analytics v4

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,10 +1,9 @@
 document.addEventListener('turbo:load', function(event) {
-  if (typeof(dataLayer) == 'undefined') return;
-
-  var url = event.data.url;
-
-  dataLayer.push({
-    'event':'pageView',
-    'virtualUrl': url
+  if (typeof(gtag) == 'undefined') return;
+  
+  // Google docs on manually creating pageviews in GA4:
+  // https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag#manually_send_page_view_events
+  gtag('event', 'page_view', {
+    page_location: event.detail.url
   });
 });

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,9 +1,0 @@
-<!-- Google Tag Manager -->
-<% if Settings.analytics.gtm_id %>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= Settings.analytics.gtm_id %>');</script>
-<!-- End Google Tag Manager -->
-<% end %>

--- a/app/views/shared/_body_preamble.html.erb
+++ b/app/views/shared/_body_preamble.html.erb
@@ -1,1 +1,0 @@
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.analytics.gtm_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -71,10 +71,11 @@ if Settings.analytics.pkcs12_key && Settings.analytics.pkcs12_key_path
   end
 end
 
+Spotlight::Engine.config.ga_web_property_id = "G-89R2218T5G"
+Spotlight::Engine.config.ga_debug_mode = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ANALYTICS_DEBUG', true))
 # Spotlight::Engine.config.analytics_provider = nil
-Spotlight::Engine.config.ga_pkcs12_key_path = Settings.analytics.pkcs12_key_path
-Spotlight::Engine.config.ga_web_property_id = Settings.analytics.web_property_id
-Spotlight::Engine.config.ga_email = Settings.analytics.email
+# Spotlight::Engine.config.ga_pkcs12_key_path = Settings.analytics.pkcs12_key_path
+# Spotlight::Engine.config.ga_email = Settings.analytics.email
 # Spotlight::Engine.config.ga_analytics_options = {}
 # Spotlight::Engine.config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)
 


### PR DESCRIPTION
- Configure analytics with GA4
- Use GA4-compatible pageview tracking with turbo

See related PR https://github.com/sul-dlss/puppet/pull/9225 to turn off debug mode in prod. You can view events live in staging or local dev using [DebugView](https://support.google.com/analytics/answer/7201382?hl=en); they don't persist or show up in data otherwise.