### PR TITLE
Allow disabling search throttling via config or envvar

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -31,5 +31,5 @@ Config.setup do |config|
 
   # Parse numeric values as integers instead of strings.
   #
-  # config.env_parse_values = true
+  config.env_parse_values = true
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -2,33 +2,36 @@ Rack::Attack.throttle("logins/ip", limit: 20, period: 1.hour) do |req|
   req.ip if req.post? && req.path.start_with?("/users/sign_in")
 end
 
-Rack::Attack.throttle("searches/ip", limit: 15, period: 15.minutes) do |req|
-  # don't throttle requests with a q, because it's more likely to be a real user
-  next if req.params['q'].present?
+# throttle bot-like search queries if configured
+if Settings.throttle_searches
+  Rack::Attack.throttle("searches/ip", limit: 15, period: 15.minutes) do |req|
+    # don't throttle requests with a q, because it's more likely to be a real user
+    next if req.params['q'].present?
 
-  # only throttle search queries
-  next unless req.path.ends_with?("/catalog")
+    # only throttle search queries
+    next unless req.path.ends_with?("/catalog")
 
-  # don't throttle the first couple pages of a search result
-  next if req.params['page'].present? && req.params['page'].to_i < 10
+    # don't throttle the first couple pages of a search result
+    next if req.params['page'].present? && req.params['page'].to_i < 10
 
-  req.ip
+    req.ip
+  end
+
+  Rack::Attack.throttled_response_retry_after_header = true
+
+  Rack::Attack.throttled_responder = lambda do |request|
+    match_data = request.env['rack.attack.match_data']
+    now = match_data[:epoch_time]
+
+    headers = {
+      'RateLimit-Limit' => match_data[:limit].to_s,
+      'RateLimit-Remaining' => '0',
+      'RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
+    }
+
+    [ 429, headers, ["Throttled\n"]]
+  end
 end
 
-Rack::Attack.throttled_response_retry_after_header = true
-
-Rack::Attack.throttled_responder = lambda do |request|
-  match_data = request.env['rack.attack.match_data']
-  now = match_data[:epoch_time]
-
-  headers = {
-    'RateLimit-Limit' => match_data[:limit].to_s,
-    'RateLimit-Remaining' => '0',
-    'RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
-  }
-
-  [ 429, headers, ["Throttled\n"]]
-end
-
-# Always allow Stanford traffic
+# always allow Stanford traffic
 Rack::Attack.safelist_ip("171.64.0.0/14")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,7 @@ contact:
 data_dir: tmp/data
 
 allow_robots: false
+throttle_searches: false
 
 feature_flags:
   allow_json_upload: true


### PR DESCRIPTION
Ref #1572

Since this sets the default to disabling search throttling, we can test that it's working correctly and then file a PR in puppet to set `THROTTLE_SEARCHES` to true for prod only to re-enable it in that environment. After that I think the issue can be closed.