### PR TITLE
Explicitly allow browse category ID in search state

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,7 +21,7 @@ class CatalogController < ApplicationController
     # Use POST requests for solr to avoid limits on query length
     config.http_method = :post
 
-    config.search_state_fields += [:exhibit_id]
+    config.search_state_fields += %i[exhibit_id browse_category_id]
 
     # Disable bookmarks
     config.index.document_actions[:bookmark].if = false


### PR DESCRIPTION
This fixes an issue where browse categories appeared to display
all items instead of filtering to the category, because we were
not sending the browse category ID to solr. Blacklight 8 strips
out unknown params from the search unless they are specified
in config.search_state_fields.

See related https://github.com/projectblacklight/spotlight/issues/2966
