### PR TITLE
Handle to str error

### DIFF
--- a/app/processors/join.rb
+++ b/app/processors/join.rb
@@ -23,6 +23,6 @@ class Join < Blacklight::Rendering::AbstractStep
   def json_api_context?
     return false unless context
 
-    context.request&.format&.json? && context.controller.is_a?(CatalogController)
+    context.request&.format&.json? && context.controller.is_a?(CatalogController) && context.action_name != 'autocomplete'
   end
 end

--- a/spec/processors/join_spec.rb
+++ b/spec/processors/join_spec.rb
@@ -20,11 +20,26 @@ RSpec.describe Join do
 
     context 'with a JSON API request' do
       let(:field_config) { Blacklight::Configuration::NullField.new(autolink: true) }
-      let(:context) { double(controller: CatalogController.new, request: double(format: double(json?: true))) }
+      let(:context) { double(controller: CatalogController.new, action_name: 'catalog', request: double(format: double(json?: true))) }
 
       it 'leaves the values as an array' do
         render
         expect(terminator).to have_received(:new).with(%w[a b],
+                                                       field_config,
+                                                       document,
+                                                       context,
+                                                       options,
+                                                       [])
+      end
+    end
+
+    context 'with JSON API for autocomplete' do
+      let(:field_config) { Blacklight::Configuration::NullField.new(autolink: true) }
+      let(:context) { double(controller: CatalogController.new, action_name: 'autocomplete', request: double(format: double(json?: true))) }
+
+      it 'joins the values like normal' do
+        render
+        expect(terminator).to have_received(:new).with('a<br>b',
                                                        field_config,
                                                        document,
                                                        context,

--- a/spec/processors/join_spec.rb
+++ b/spec/processors/join_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe Join do
     let(:values) { %w[a b] }
     let(:field_config) { Blacklight::Configuration::NullField.new }
 
-    context 'with a JSON API request' do
+    context 'with a JSON API request from the catalog controller that is not autocomplete' do
       let(:field_config) { Blacklight::Configuration::NullField.new(autolink: true) }
-      let(:context) { double(controller: CatalogController.new, action_name: 'catalog', request: double(format: double(json?: true))) }
+      let(:request) { double(format: double(json?: true)) }
+      let(:context) { double(controller: CatalogController.new, action_name: 'index', request: request) }
 
       it 'leaves the values as an array' do
         render
@@ -33,9 +34,10 @@ RSpec.describe Join do
       end
     end
 
-    context 'with JSON API for autocomplete' do
+    context 'with a JSON API request for autocomplete' do
       let(:field_config) { Blacklight::Configuration::NullField.new(autolink: true) }
-      let(:context) { double(controller: CatalogController.new, action_name: 'autocomplete', request: double(format: double(json?: true))) }
+      let(:request) { double(format: double(json?: true)) }
+      let(:context) { double(controller: CatalogController.new, action_name: 'autocomplete', request: request) }
 
       it 'joins the values like normal' do
         render
@@ -48,7 +50,7 @@ RSpec.describe Join do
       end
     end
 
-    context 'with a JSON API require that is not the JSON API' do
+    context 'with a JSON API request that is not the JSON API' do
       let(:field_config) { Blacklight::Configuration::NullField.new(autolink: true) }
       let(:context) { double(controller: ApplicationController.new, request: double(format: double(json?: true))) }
 


### PR DESCRIPTION
This code handles the error described in https://github.com/orgs/sul-dlss/projects/53?pane=issue&itemId=21913854 .  By distinguishing between an autocomplete request, where we do want strings returned instead of arrays, and other JSON API requests related to the catalog controller where we want arrays returned, we should be able to handle the to_str error which occurs because the autocomplete code in Spotlight was receiving an array instead of the expected string.  Rspec tests have been updated to reflect this difference between a regular JSON API catalog controller request and an autocomplete request.  Added the action name "index" for the regular JSON API catalog controller, since that is one situation (when using the "/raw" option at the end of a catalog page) where the Join render is used again . 