### PR TITLE
Remove carrierwave-aws gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ group :development do
 end
 
 group :production do
-  gem 'carrierwave-aws'
   gem 'pg'
   gem 'sidekiq', '~> 7.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,22 +78,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.730.0)
-    aws-sdk-core (3.170.1)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.63.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.119.1)
-      aws-sdk-core (~> 3, >= 3.165.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.2)
-      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     better_html (2.0.1)
       actionview (>= 6.0)
@@ -214,9 +198,6 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
-    carrierwave-aws (1.5.0)
-      aws-sdk-s3 (~> 1.0)
-      carrierwave (~> 2.0)
     clipboard-rails (1.7.1)
     concurrent-ruby (1.2.2)
     config (4.1.0)
@@ -357,7 +338,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jmespath (1.6.2)
     json (2.6.3)
     jwt (2.7.0)
     kaminari (1.2.2)
@@ -697,7 +677,6 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capybara (~> 3.0)
-  carrierwave-aws
   config
   cssbundling-rails (~> 1.1)
   debug


### PR DESCRIPTION
Because we're not using S3 anymore