### PR TITLE
Unlock the capfile

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.17.1"
+# lock "~> 3.17.1"
 
 set :application, "dlme"
 set :repo_url, "https://github.com/sul-dlss/dlme.git"


### PR DESCRIPTION
Currently this won't deploy and gives the message:
```
Capfile locked at ~> 3.17.1, but 3.18.0 is loaded
```

We do not use the lock function in other projects to avoid this problem.