### PR TITLE
Add accessibility contact information to footer

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -25,6 +25,16 @@
     justify-content: center;
   }
 
+  .accessibility-contact {
+    justify-content: left;
+    color: $color-gray-light;
+
+    a {
+      color: $color-gray-light;
+      text-decoration: underline;
+    }
+  }
+
   .logo {
     align-self: center;
     flex-grow: 1;

--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -76,6 +76,12 @@ $breadcrumb-item-padding-x: 0.5rem !default;
     }
   }
 
+  /** Adjust accessibility information display (used in the footer) */
+  .accessibility-contact {
+    justify-content: right;
+  }
+
+
   /** Blacklight-specific overrides */
   #skip-link {
     left: inherit;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -24,7 +24,7 @@ $link-color: lighten($color-primary, 10%);
 $body-background-color: #f7f7f7;
 
 $footer-background-color: $color-primary;
-$footer-height: 120px;
+$footer-height: 160px;
 $footer-top-margin: 20px;
 $footer-mobile-adjustment: 100px;
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,7 @@
 <footer class="footer" role="contentinfo">
+  <div class="container accessibility-contact">
+    <p><%= t('footer.accessibility_html', accessibility_email: Settings.accessibility_email) %></p>
+  </div>
   <div class="container">
     <div class="logo clir">
       <a href="https://www.clir.org/">

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -102,6 +102,7 @@ ar:
   embed:
     view_on_contributor_website: اعرض على موقع المساهمين
   footer:
+    accessibility_html: إذا لم تتمكن من الوصول إلى المحتوى أو استخدام ميزات هذا الموقع بسبب الإعاقة، يرجى <a href='mailto:%{accessibility_email}'>الإبلاغ عن مشكلة إمكانية الوصول</a>
     partnership_heading: بالشراكة مع
     project_support_heading: المشروع مدعوم من قبل
     project_support_text: مؤسسة أندرو و. ميلون

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
   embed:
     view_on_contributor_website: View on contributor website
   footer:
+    accessibility_html: If you cannot access content or use features on this website due to a disability, please <a href='mailto:%{accessibility_email}'>report your accessibility issue</a>.
     partnership_heading: In partnership with
     project_support_heading: Project supported by
     project_support_text: The Andrew W. Mellon Foundation

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,7 @@ cache_period: <%= 12.hours %>
 contact:
   email: ~
 
+accessibility_email: 'library-accessibility-contact@lists.stanford.edu'
 
 data_dir: tmp/data
 


### PR DESCRIPTION
Closes #1819 

@astridu this implementation differs slightly from what's specified in #1819. I opted to align the accessibility statement with the text in the main body of the page to reduce awkward breaks in the text at different screen sizes.

<img width="1063" alt="Screenshot 2023-12-14 at 1 12 49 PM" src="https://github.com/sul-dlss/dlme/assets/458247/39b92715-baea-4cca-bf59-cc7a16c58328">
<img width="1042" alt="Screenshot 2023-12-14 at 1 10 48 PM" src="https://github.com/sul-dlss/dlme/assets/458247/d94766cf-1896-487f-b094-a021aa7c52e9">
