### PR TITLE
Pin blacklight to 8.1.0 until JS in 8.2 is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,8 @@ group :deployment do
   gem 'dlss-capistrano'
 end
 
-gem 'blacklight', '~> 8.1'
+# Pin Blacklight to 8.1.0 until a fix is in for: https://github.com/projectblacklight/blacklight/commit/d8c0ec4435db34b85f83a2e4799bc15b0469ef27
+gem 'blacklight', '~> 8.1.0'
 gem 'blacklight-spotlight', '~> 3.6.0.beta6'
 
 gem 'friendly_id'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,10 +90,11 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bigdecimal (3.1.8)
     bindex (0.8.1)
-    blacklight (8.2.0)
+    blacklight (8.1.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
@@ -291,7 +292,9 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
-    ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -418,6 +421,8 @@ GEM
       net-protocol
     net-ssh (7.2.3)
     nio4r (2.7.3)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -647,6 +652,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     sshkit (1.22.2)
@@ -703,6 +709,7 @@ GEM
     zeitwerk (2.6.15)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
@@ -710,7 +717,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  blacklight (~> 8.1)
+  blacklight (~> 8.1.0)
   blacklight-gallery (~> 4.2)
   blacklight-hierarchy (~> 6.1)
   blacklight-oembed (>= 0.1.0)


### PR DESCRIPTION
JS imports are broken in Blacklight 8.2
Commit that broke it: https://github.com/projectblacklight/blacklight/commit/d8c0ec4435db34b85f83a2e4799bc15b0469ef27
Proposing a revert: https://github.com/projectblacklight/blacklight/pull/3164