### PR TITLE
Add wait to flaky alert tests

### DIFF
--- a/spec/features/contextual_date_sort_message_spec.rb
+++ b/spec/features/contextual_date_sort_message_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Contextual date sort message on search results' do
       click_link('Date (old to new)')
     end
     within '#content' do
-      expect(page).to have_css '.date-sort-message'
+      expect(page).to have_css '.date-sort-message', wait: 30
       within '.date-sort-message' do
         click_button 'Dismiss'
       end

--- a/spec/features/contextual_result_message_spec.rb
+++ b/spec/features/contextual_result_message_spec.rb
@@ -41,19 +41,19 @@ RSpec.describe 'Contextual result message on search results' do
 
   it 'renders info alert, that is dismissable', js: true do
     within '#content' do
-      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query', wait: 30
       click_button 'Dismiss'
       expect(page).to have_no_css '.alert.alert-info'
     end
     click_button 'Search'
     within '#content' do
-      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query', wait: 30
     end
   end
 
   it 'renders info alert, that is not shown again in the session', js: true do
     within '#content' do
-      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query'
+      expect(page).to have_css '.alert.alert-info', text: 'You might see more results for your query', wait: 30
       click_button 'Don\'t show again'
       expect(page).to have_no_css '.alert.alert-info'
     end


### PR DESCRIPTION
These alert related tests are flaky now, both locally and in CI, maybe due to a recent chromedriver update? Increasing how long Capybara will wait for the alert to appear seems to fix the issue.