### PR TITLE
Check that search_state.query_param responds to match?

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -25,7 +25,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   # more advanced search queries. Setting `mm=1` means only 1 clause needs to match, but the lucene query parser (in
   # edismax) will precompose the query strings so everything works out.
   def min_match_for_boolean(solr_parameters)
-    return unless search_state.query_param&.match?(/\s(AND|OR|NOT)\s/)
+    return unless search_state.query_param.respond_to?(:match?) &&
+                  search_state.query_param&.match?(/\s(AND|OR|NOT)\s/)
 
     solr_parameters[:mm] = '1'
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe SearchBuilder do
         expect(solr_parameters[:mm]).to be_nil
       end
     end
+
+    context "when the query isn't a string" do
+      let(:query) { { q: { a: 1 } } }
+
+      it 'does not set min match' do
+        expect(solr_parameters[:mm]).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes:

```
ActionView::Template::Error (undefined method `match?' for {"id"=>["p15795coll32:68160"]}:ActiveSupport::HashWithIndifferentAccess)
```
which occurs when an item is embedded in a search context, like the exhibit home page.