### PR TITLE
Update skiplink classes for Blacklight 8

### DIFF
--- a/app/assets/stylesheets/rtl.scss
+++ b/app/assets/stylesheets/rtl.scss
@@ -83,11 +83,6 @@ $breadcrumb-item-padding-x: 0.5rem !default;
 
 
   /** Blacklight-specific overrides */
-  #skip-link {
-    left: inherit;
-    right: 10px;
-  }
-
   .facet-field-heading button::after {
     float: left;
     transform: rotate(-90deg);

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -25,13 +25,15 @@
   </head>
   <body class="<%= render_body_class %>">
     <%= render partial: 'shared/body_preamble' %>
-    <div id="skip-link">
-      <% if should_render_spotlight_search_bar? %>
-        <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbo: false } %>
-      <% end %>
-      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbo: false } %>
-      <%= content_for(:skip_links) %>
-    </div>
+    <nav id="skip-link" role="navigation" class="visually-hidden-focusable sr-only sr-only-focusable" aria-label="<%= t('blacklight.skip_links.label') %>">
+      <div class="container-xl">
+        <% if should_render_spotlight_search_bar? %>
+          <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'd-inline-flex p-2 m-1', data: { turbo: 'false' } %>
+        <% end %>
+        <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'd-inline-flex p-2 m-1', data: { turbo: 'false' } %>
+        <%= content_for(:skip_links) %>
+      </div>
+    </nav>
 
     <%= render partial: 'shared/header_navbar' %>
     <%= render partial: 'shared/masthead' %>


### PR DESCRIPTION
Fixes skiplink display issue in DLME.

Current prod:
<img width="528" alt="Screenshot 2024-09-27 at 9 41 54 AM" src="https://github.com/user-attachments/assets/88aad87a-e10e-4b0f-a08b-ec695b48319a">

With this PR:
<img width="488" alt="Screenshot 2024-09-27 at 9 42 00 AM" src="https://github.com/user-attachments/assets/93ab1517-3050-449a-b62b-d9c6dd526574">
