### PR TITLE
Extract a header component

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,7 +1,7 @@
 <span class="background-container-gradient"></span>
 <nav class="navbar navbar-expand navbar-dark topbar" role="navigation" aria-label="<%= t('spotlight.topbar.label') %>">
-  <div class="<%= container_classes %>">
-    <%= link_to main_app.root_url, class: 'navbar-brand' do %>
+  <div class="<%= helpers.container_classes %>">
+    <%= link_to helpers.main_app.root_url, class: 'navbar-brand' do %>
       <%= image_tag 'logo.png', class: 'dlme-logo', alt: '', role: 'presentation' %>
       <%= t('application_name') %>
     <% end %>

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class HeaderComponent < Spotlight::HeaderComponent
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,6 +62,7 @@ class CatalogController < ApplicationController
     config.crawler_detector = ->(req) { req.env['HTTP_USER_AGENT'] && req.env['HTTP_USER_AGENT'] =~ /bot/i }
     config.max_page = 100
 
+    config.header_component = HeaderComponent
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
     config.raw_endpoint.enabled = true


### PR DESCRIPTION
This avoids a deprecation warning from Spotlight