### PR TITLE
Restore Spotlight javascript

### DIFF
--- a/app/assets/javascripts/blacklight_gallery.js
+++ b/app/assets/javascripts/blacklight_gallery.js
@@ -1,0 +1,1 @@
+//= require blacklight_gallery/blacklight-gallery

--- a/app/assets/javascripts/spotlight.js
+++ b/app/assets/javascripts/spotlight.js
@@ -1,0 +1,10 @@
+// require the parts of spotlight/application rather than using it directly in order to
+// work around https://github.com/projectblacklight/spotlight/pull/2921
+
+//= require leaflet
+//= require sir-trevor
+//= require clipboard
+//= require tiny-slider
+//= require typeahead.bundle.min.js
+
+//= require spotlight/spotlight

--- a/app/javascript/entry.js
+++ b/app/javascript/entry.js
@@ -1,5 +1,8 @@
 // This is the entrypoint for the importmap build.
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import jQuery from 'jquery'
+window.jQuery = jQuery
+window.$ = jQuery
 
 import "@hotwired/turbo-rails"
 
@@ -8,13 +11,11 @@ import "controllers"
 import 'bootstrap'
 import Blacklight from 'blacklight'
 import 'openseadragon-rails/rails'
-import 'blacklight-gallery'
 
 window.Blacklight = Blacklight
 
 import { I18n } from 'i18n-js'
 export const i18n = new I18n()
-window.i18n = i18n
 
 import 'transform_result'
 import 'blacklight-hierarchy'

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -18,7 +18,6 @@
     <%= description %>
     <%= twitter_card %>
     <%= opengraph %>
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <%= javascript_importmap_tags 'entry' %>
     <%= javascript_include_tag "application", defer: true %>
     <%= javascript_tag "window.addEventListener('load', () => window.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}')" %>

--- a/vendor/javascript/blacklight-hierarchy.js
+++ b/vendor/javascript/blacklight-hierarchy.js
@@ -1,5 +1,6 @@
-// This import is not part of the downloaded asset. It is needed to make the include in entry.js via importmap work as expected.
+// These imports are not part of the downloaded asset. They are needed to make the include in entry.js via importmap work as expected.
 import Blacklight from 'blacklight-frontend'
+import jQuery from 'jquery'
 
 // blacklight-hierarchy@6.4.0 downloaded from https://ga.jspm.io/npm:blacklight-hierarchy@6.4.0/app/assets/javascripts/blacklight/hierarchy/hierarchy.js
 


### PR DESCRIPTION
Closes #1947

I missed that https://github.com/sul-dlss/dlme/pull/1934 deleted the Spotlight javascript.

Spotlight v4 depends on the Bootstrap jQuery integration, so the global jQuery *must* be the same jQuery that bootstrap 4 imports via the importmap. This requires rolling back part of my change from #1941.

blacklight-hierarchy needs jQuery, but I think we're fine to cheese that here in the vendor file. Blacklight-hierarchy doesn't get updated, and we need to replace the use of it anyway.

blacklight-gallery wants global jQuery. We can't provide that within the context of entry.js, we'd have to add rollup or change blacklight-gallery? For now, I've switched back to including via sprockets to see if it gets the site running again.