### PR TITLE
Update to Spotlight 4.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
-    blacklight (8.7.0)
+    blacklight (8.8.0)
       globalid
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
@@ -108,7 +108,7 @@ GEM
       rails (>= 6.1, < 9)
       view_component (>= 2.74, < 4)
       zeitwerk
-    blacklight-gallery (4.8.3)
+    blacklight-gallery (4.8.4)
       blacklight (>= 7.17, < 9)
       rails (>= 6.1, < 9)
     blacklight-hierarchy (6.4.0)
@@ -119,7 +119,7 @@ GEM
       blacklight (>= 7.25, < 9)
       rails
       ruby-oembed
-    blacklight-spotlight (4.6.1)
+    blacklight-spotlight (4.7.0)
       activejob-status
       acts-as-taggable-on (>= 5.0, < 12)
       autoprefixer-rails
@@ -314,7 +314,7 @@ GEM
       railties (>= 3.2, < 9.0)
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
-    gapic-common (0.24.0)
+    gapic-common (0.25.0)
       faraday (>= 1.9, < 3.a)
       faraday-retry (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
@@ -356,7 +356,7 @@ GEM
       grpc (~> 1.41)
     googleapis-common-protos-types (1.18.0)
       google-protobuf (>= 3.18, < 5.a)
-    googleauth (1.12.2)
+    googleauth (1.13.1)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -419,7 +419,8 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.0)
-    irb (1.14.3)
+    irb (1.15.1)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.13.0)
@@ -479,7 +480,6 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
-      net-protocol
     net-protocol (0.2.2)
       timeout
     net-scp (4.0.0)
@@ -517,6 +517,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     psych (5.2.3)
       date
       stringio

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -18,9 +18,9 @@
     <%= description %>
     <%= twitter_card %>
     <%= opengraph %>
+    <%= javascript_tag "window.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}'" %>
     <%= javascript_importmap_tags 'entry' %>
     <%= javascript_include_tag "application", defer: true %>
-    <%= javascript_tag "window.addEventListener('load', () => window.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}')" %>
     <%= javascript_tag "window.addEventListener('load', () => $.fx.off = true)" if Rails.env.test? %>
   </head>
   <body class="<%= render_body_class %>">

--- a/spec/features/spotlight_frontend_spec.rb
+++ b/spec/features/spotlight_frontend_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Spotlight Frontend', :js do
+  let(:exhibit) { create(:exhibit) }
+  let(:curator) { create(:exhibit_curator, exhibit: exhibit) }
+
+  describe 'block editor' do
+    before do
+      login_as curator
+      visit spotlight.exhibit_dashboard_path(exhibit)
+      click_link 'Feature pages'
+      within('.home_page') do
+        click_link 'Edit'
+      end
+    end
+
+    it 'renders the block editor' do
+      expect(page).to have_css('.st-blocks')
+    end
+
+    it 'renders the block editor icons' do
+      within('.st-block-replacer') do
+        href_value = find('use')['xlink:href']
+        expect(href_value).to match(/.+\.svg#add-block$/)
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,17 +1662,24 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-"blacklight-frontend@>=7.1 || 8.0", "blacklight-frontend@>=7.1.0 <9", blacklight-frontend@^8.2.1:
+"blacklight-frontend@>=7.1 || 8.0":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.7.0.tgz#4ef0d5c984ea41addf42914dd37157f7eee3f3f5"
   integrity sha512-iDPNfD+QQo5+ZoLLl4uRXtgzvPFup4JnzAa1MnxdP+7cxkHm24cidJ+c/9UBZjk9mrOOnFdlMfWZnbX+zG+mkQ==
   dependencies:
     bootstrap ">=4.3.1 <6.0.0"
 
+"blacklight-frontend@>=7.1.0 <9", blacklight-frontend@^8.2.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-8.8.0.tgz#c3a413b5e4f0b50ae134bc385346ee0f70d5cfea"
+  integrity sha512-K0kN+h2HEnEINE1ewqwTvMNP5lWI52TkMfLTr+tWlFVJUdG+CcJKDW0B5fTfZ8q2pSWy54QUgHzhVMYjk5EOow==
+  dependencies:
+    bootstrap ">=4.3.1 <6.0.0"
+
 blacklight-gallery@^4.0.2-beta.1:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/blacklight-gallery/-/blacklight-gallery-4.8.3.tgz#89348d219283032eb8d5148ca9d3edfb3358da37"
-  integrity sha512-6DH69u654+gKvtjXJvIAeBw3njg2SCGWxPaeKZVMwtHdA2ok2HqMiRLKX2sK5w6bHRDPfhLDFy58q6lggRv0vA==
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/blacklight-gallery/-/blacklight-gallery-4.8.4.tgz#7c1377dcd0d7a0c61a09c4268478c9a64da47a08"
+  integrity sha512-5ZDarJ+IXBDqlhWz02EsxArQi/Y2oFyzwKqVEwwLSowwikWFBpWiBQnNWKbDwQOf7np5fv7Zo9z3SZ1vR6PLsQ==
   dependencies:
     blacklight-frontend ">=7.1.0 <9"
     jquery ">=3.0"


### PR DESCRIPTION
Spotlight 4.7.0 allows us to fix the Sir Trevor icon loading issue.

Added tests to check if the block editor & the icons render. I think this is a decent indicator if the spotlight-frontend JavaScript is actually running.