### PR TITLE
Update rack-mini-profiler to v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
+  gem 'rack-mini-profiler', '~> 4.0'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -532,7 +532,7 @@ GEM
     rack (3.2.4)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-mini-profiler (2.3.4)
+    rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-proxy (0.7.7)
       rack
@@ -848,7 +848,7 @@ DEPENDENCIES
   okcomputer
   pg
   puma (~> 7.0)
-  rack-mini-profiler (~> 2.0)
+  rack-mini-profiler (~> 4.0)
   rails (~> 7.2.2)
   rails-controller-testing
   rails_autolink


### PR DESCRIPTION
Removes local warning: `Rack app ("GET /mini-profiler-resources/includes.jsv=35a79b300ab5afa978cb59af0b05e059" - (::1)): #<NameError: uninitialized constant Rack::File>`