### PR TITLE
Remove shakapacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,8 +100,6 @@ gem 'slowpoke', '~> 0.4'
 
 gem 'font-awesome-rails'
 
-gem 'shakapacker', '~> 6.4'
-
 gem 'cache_with_locale'
 
 gem 'i18n-tasks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,6 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.3-arm64-darwin)
-    ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
@@ -340,9 +339,6 @@ GEM
     google-protobuf (4.33.3-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.3-x86_64-darwin)
-      bigdecimal
-      rake (>= 13)
     google-protobuf (4.33.3-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
@@ -364,9 +360,6 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.76.0-arm64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.76.0-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.76.0-x86_64-linux-gnu)
@@ -497,8 +490,6 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.18)
@@ -524,7 +515,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.3-arm64-darwin)
-    pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
@@ -542,8 +532,6 @@ GEM
       rack (>= 1.0, < 4)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
-    rack-proxy (0.7.7)
-      rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -706,12 +694,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    semantic_range (3.1.0)
-    shakapacker (6.6.0)
-      activesupport (>= 5.2)
-      rack-proxy (>= 0.6.1)
-      railties (>= 5.2)
-      semantic_range (>= 2.3.0)
     sidekiq (8.0.10)
       connection_pool (>= 2.5.0)
       json (>= 2.9.0)
@@ -754,7 +736,6 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     sqlite3 (2.9.0-arm64-darwin)
-    sqlite3 (2.9.0-x86_64-darwin)
     sqlite3 (2.9.0-x86_64-linux-gnu)
     sshkit (1.25.0)
       base64
@@ -814,6 +795,7 @@ GEM
     zeitwerk (2.7.4)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-24
   arm64-darwin-25
   x86_64-linux
@@ -870,7 +852,6 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   selenium-webdriver
-  shakapacker (~> 6.4)
   sidekiq (~> 8.0)
   simplecov (~> 0.21)
   sitemap_generator


### PR DESCRIPTION
```
13:07:29 web.1  | /Users/sctaylor/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/shakapacker-6.6.0/lib/webpacker/configuration.rb:119:in 'Webpacker::Configuration#load': Webpacker configuration file not found /Users/sctaylor/Development/dlme/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_sysopen - /Users/sctaylor/Development/dlme/config/webpacker.yml (RuntimeError)
```

Seems like https://github.com/sul-dlss/dlme/pull/2056 meant to remove this as well.